### PR TITLE
Environment cleanup

### DIFF
--- a/spag.py
+++ b/spag.py
@@ -19,7 +19,7 @@ def determine_endpoint(f):
     def wrapper(*args, **kwargs):
         if kwargs['endpoint'] is None:
             try:
-                endpoint = spag_files.SpagEnvironment.get_env()['endpoint']
+                endpoint = spag_files.SpagEnvironment.get_env()['envvars']['endpoint']
                 kwargs['endpoint'] = endpoint
             except ToughNoodles as e:
                 click.echo(str(e), err=True)
@@ -252,14 +252,13 @@ def env_show(envname=None):
         sys.exit(1)
 
 @env.command('set')
-@click.argument('endpoint', default=None, required=False)
 @click.option('--header', '-H', multiple=True,
               default=None, help='Header in the form key:value')
 @click.option('--envvars', '-E', multiple=True,
               default=None, help='Environment variables in the form key=value')
-def env_set(endpoint=None, header=None, envvars=None):
-    """Set the endpoint and/or headers."""
-    if endpoint is None and header == () and envvars == ():
+def env_set(header=None, envvars=None):
+    """Set the environment variables and/or headers."""
+    if header == () and envvars == ():
         click.echo("Error: You must provide something to set!", err=True)
         sys.exit(1)
 
@@ -268,8 +267,8 @@ def env_set(endpoint=None, header=None, envvars=None):
     header = {key: value.strip() for (key, value) in [h.split(':') for h in header]}
 
     # Determine which args should be passed to a dict-style update function
-    kwargs = {'endpoint': endpoint, 'headers': header, 'envvars': envvars}
-    for arg in ['endpoint', 'headers', 'envvars']:
+    kwargs = {'headers': header, 'envvars': envvars}
+    for arg in ['headers', 'envvars']:
         if not kwargs[arg]:
             kwargs.pop(arg)
 
@@ -281,9 +280,9 @@ def env_set(endpoint=None, header=None, envvars=None):
         sys.exit(1)
 
 @env.command('unset')
-@click.argument('resource', required=True)
+@click.argument('resource', required=False)
 @click.option('--everything', is_flag=True, default=False)
-def env_unset(resource, everything=False):
+def env_unset(resource=None, everything=False):
     try:
         env = spag_files.SpagEnvironment().unset_env(resource, everything)
         click.echo(yaml.safe_dump(env, default_flow_style=False))

--- a/tests/test_spag.py
+++ b/tests/test_spag.py
@@ -97,8 +97,8 @@ class TestGet(BaseTest):
         self.assertEqual(json.loads(out), {"token": "abcde"})
 
     def test_get_presupply_endpoint(self):
-        out, err, ret = run_spag('env', 'set', ENDPOINT)
-        self.assertEqual(out, 'endpoint: {0}\n\n'.format(ENDPOINT))
+        out, err, ret = run_spag('env', 'set', '-E', 'endpoint=%s' % ENDPOINT)
+        self.assertEqual(out, 'envvars:\n  endpoint: {0}\n\n'.format(ENDPOINT))
         self.assertEqual(err, '')
         self.assertEqual(ret, 0)
         out, err, ret = run_spag('get', '/things')
@@ -109,7 +109,7 @@ class TestGet(BaseTest):
 class TestPost(BaseTest):
 
     def test_spag_post(self):
-        run_spag('env', 'set', ENDPOINT)
+        run_spag('env', 'set', '-E', 'endpoint=%s' % ENDPOINT)
         out, err, ret = run_spag('post', '/things', '--data', '{"id": "a"}',
                                  '-H', 'content-type:application/json')
         self.assertEquals(ret, 0)
@@ -119,7 +119,7 @@ class TestPost(BaseTest):
 class TestPut(BaseTest):
 
     def test_spag_put(self):
-        run_spag('env', 'set', ENDPOINT)
+        run_spag('env', 'set', '-E', 'endpoint=%s' % ENDPOINT)
         out, err, ret = run_spag('post', '/things', '--data', '{"id": "a"}',
                                  '-H', 'content-type:application/json')
         self.assertEquals(ret, 0)
@@ -134,7 +134,7 @@ class TestPut(BaseTest):
 class TestPatch(BaseTest):
 
     def test_spag_patch(self):
-        run_spag('env', 'set', ENDPOINT)
+        run_spag('env', 'set', '-E', 'endpoint=%s' % ENDPOINT)
         out, err, ret = run_spag('post', '/things', '--data', '{"id": "a"}',
                                  '-H', 'content-type:application/json')
         self.assertEquals(ret, 0)
@@ -149,7 +149,7 @@ class TestPatch(BaseTest):
 class TestDelete(BaseTest):
 
     def test_spag_delete(self):
-        run_spag('env', 'set', ENDPOINT)
+        run_spag('env', 'set', '-E', 'endpoint=%s' % ENDPOINT)
         out, err, ret = run_spag('post', '/things', '--data', '{"id": "a"}',
                                  '-H', 'content-type:application/json')
         self.assertEquals(ret, 0)
@@ -169,7 +169,7 @@ class TestSpagFiles(BaseTest):
 
     def setUp(self):
         super(TestSpagFiles, self).setUp()
-        run_spag('env', 'set', ENDPOINT)
+        run_spag('env', 'set', '-E', 'endpoint=%s' % ENDPOINT)
         run_spag('env', 'set', '-E', 'dir=%s' % RESOURCES_DIR)
         self.table = spag_files.SpagFilesLookup(RESOURCES_DIR)
 
@@ -279,7 +279,7 @@ class TestSpagFiles(BaseTest):
         self.assertEqual(ret, 0)
 
     def test_spag_environment_crud(self):
-        out, err, ret = run_spag('env', 'set', 'abcdefgh')
+        out, err, ret = run_spag('env', 'set', '-E', 'endpoint=abcdefgh')
         self.assertIn('endpoint: abcdefgh', out)
         self.assertEqual(err, '')
         self.assertEqual(ret, 0)
@@ -289,7 +289,7 @@ class TestSpagFiles(BaseTest):
         self.assertEqual(err, '')
         self.assertEqual(ret, 0)
 
-        out, err, ret = run_spag('env', 'unset', 'endpoint', '--everything')
+        out, err, ret = run_spag('env', 'unset', '--everything')
         self.assertEqual(err, '')
         self.assertEqual(ret, 0)
 
@@ -299,11 +299,11 @@ class TestSpagFiles(BaseTest):
         self.assertEqual(ret, 0)
 
     def test_spag_environment_activate_deactivate(self):
-        out, err, ret = run_spag('env', 'unset', 'endpoint', '--everything')
+        out, err, ret = run_spag('env', 'unset', '--everything')
         self.assertEqual(err, '')
         self.assertEqual(ret, 0)
 
-        out, err, ret = run_spag('env', 'set', 'abcdefgh')
+        out, err, ret = run_spag('env', 'set', '-E', 'endpoint=abcdefgh')
         self.assertIn('endpoint: abcdefgh', out)
         self.assertEqual(err, '')
         self.assertEqual(ret, 0)
@@ -323,7 +323,7 @@ class TestSpagFiles(BaseTest):
         self.assertNotEqual(ret, 0)
 
     def test_set_endoint_and_header(self):
-        out, err, ret = run_spag('env', 'set', ENDPOINT, '-H', 'pglbutt:pglbutt')
+        out, err, ret = run_spag('env', 'set', '-E', 'endpoint=%s' % ENDPOINT, '-H', 'pglbutt:pglbutt')
         self.assertEqual(err, '')
         self.assertEqual(ret, 0)
         self.assertIn('headers', out)
@@ -336,7 +336,7 @@ class TestSpagRemembers(BaseTest):
 
     def setUp(self):
         super(TestSpagRemembers, self).setUp()
-        run_spag('env', 'set', ENDPOINT)
+        run_spag('env', 'set', '-E', 'endpoint=%s' % ENDPOINT)
 
     def test_spag_remembers_request(self):
         auth_file = os.path.join(SPAG_REMEMBERS_DIR, 'v2/post_thing.yml')
@@ -406,7 +406,7 @@ class TestSpagTemplate(BaseTest):
 
     def setUp(self):
         super(TestSpagTemplate, self).setUp()
-        assert run_spag('env', 'set', ENDPOINT)[2] == 0
+        assert run_spag('env', 'set', '-E', 'endpoint=%s' % ENDPOINT)[2] == 0
         assert run_spag('env', 'set', '-E', 'dir=%s' % TEMPLATES_DIR)
 
     def test_spag_template_with_keyword(self):


### PR DESCRIPTION
- Moves 'endpoint' to an envvar
    So `spag env set -E endpoint=http://blah` is now used instead of setting endpoint by default
- Makes spag unset not have a mandatory resource so you can `spag unset --everything` or `spag unset endpoint
- Little bit of code cleanup in Environments

closes #22