### PR TITLE
Make environment sets make sense

### DIFF
--- a/decorators.py
+++ b/decorators.py
@@ -12,7 +12,7 @@ def determine_endpoint(f):
         env = spag_files.SpagEnvironment.get_env()
         if kwargs['endpoint'] is None:
             try:
-                endpoint = env['envvars']['endpoint']
+                endpoint = env['endpoint']
                 kwargs['endpoint'] = endpoint
             except ToughNoodles as e:
                 click.echo(str(e), err=True)
@@ -61,7 +61,7 @@ def request_dir(f):
 
         if kwargs['dir'] is None:
             try:
-                d = env['envvars']['dir']
+                d = env['dir']
                 kwargs['dir'] = d
             except ToughNoodles as e:
                 click.echo(str(e), err=True)

--- a/decorators.py
+++ b/decorators.py
@@ -1,0 +1,88 @@
+import sys
+import functools
+
+import click
+
+import spag_files
+from common import ToughNoodles, update
+
+def determine_endpoint(f):
+    @functools.wraps(f)
+    def wrapper(*args, **kwargs):
+        env = spag_files.SpagEnvironment.get_env()
+        if kwargs['endpoint'] is None:
+            try:
+                endpoint = env['envvars']['endpoint']
+                kwargs['endpoint'] = endpoint
+            except ToughNoodles as e:
+                click.echo(str(e), err=True)
+                sys.exit(1)
+            except KeyError:
+                click.echo('Endpoint not set\n', err=True)
+                sys.exit(1)
+        return f(*args, **kwargs)
+    return wrapper
+
+def prepare_headers(f):
+    @functools.wraps(f)
+    def wrapper(*args, **kwargs):
+        env = spag_files.SpagEnvironment.get_env()
+        header = kwargs['header']
+        if header is None or header == ():
+            try:
+                headers = env['headers']
+                kwargs['header'] = headers
+            except ToughNoodles:
+                kwargs['header'] = None
+            except KeyError:
+                kwargs['header'] = None
+        else:
+            try:
+                # Headers come in as a tuple ('Header:Content', 'Header:Content')
+                supplied_headers = {key: value.strip() for (key, value) in [h.split(':') for h in header]}
+                if 'headers' in env:
+                    headers = update(env['headers'], supplied_headers)
+                else:
+                    headers = supplied_headers
+                kwargs['header'] = headers
+            except ValueError:
+                click.echo("Error: Invalid header!", err=True)
+                sys.exit(1)
+            except KeyError:
+                kwargs['header'] = {key: value.strip() for (key, value) in [h.split(':') for h in header]}
+
+        return f(*args, **kwargs)
+    return wrapper
+
+def request_dir(f):
+    @functools.wraps(f)
+    def wrapper(*args, **kwargs):
+        env = spag_files.SpagEnvironment.get_env()
+
+        if kwargs['dir'] is None:
+            try:
+                d = env['envvars']['dir']
+                kwargs['dir'] = d
+            except ToughNoodles as e:
+                click.echo(str(e), err=True)
+                sys.exit(1)
+            except KeyError:
+                click.echo('Request directory not set\n', err=True)
+                sys.exit(1)
+        return f(*args, **kwargs)
+    return wrapper
+
+def common_request_args(f):
+    @click.option('--endpoint', '-e', metavar='<endpoint>',
+                  default=None, help='Manually override the endpoint')
+    @click.option('--header', '-H', metavar = '<header>', multiple=True,
+                  default=None, help='Header in the form Key:Value')
+    @click.option('--show-headers', '-h', is_flag=True,
+                  help='Prints the headers along with the response body')
+    @click.option('--data', '-d', required=False, help='the request data')
+    @determine_endpoint
+    @prepare_headers
+    @functools.wraps(f)
+    def wrapper(*args, **kwargs):
+        return f(*args, **kwargs)
+    return wrapper

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ setup(name='noodles',
       author='pglbutt',
       author_email='pglbutt@pglbutt.com',
       license='MIT',
-      py_modules=['spag', 'spag_files', 'spag_remembers', 'common', 'spag_template'],
+      py_modules=['spag', 'spag_files', 'spag_remembers', 'common', 'spag_template', 'decorators'],
       install_requires=[
         'Click',
       ],

--- a/spag.py
+++ b/spag.py
@@ -175,11 +175,10 @@ def env_show(envname=None):
         sys.exit(1)
 
 @env.command('set')
+@click.argument('envvars', nargs=-1, required=False)
 @click.option('--header', '-H', multiple=True,
               default=None, help='Header in the form key:value')
-@click.option('--envvars', '-E', multiple=True,
-              default=None, help='Environment variables in the form key=value')
-def env_set(header=None, envvars=None):
+def env_set(envvars=None, header=None):
     """Set the environment variables and/or headers."""
     if header == () and envvars == ():
         click.echo("Error: You must provide something to set!", err=True)
@@ -189,14 +188,11 @@ def env_set(header=None, envvars=None):
     envvars = {key: value for (key, value) in [e.split('=') for e in envvars]}
     header = {key: value.strip() for (key, value) in [h.split(':') for h in header]}
 
-    # Determine which args should be passed to a dict-style update function
-    kwargs = {'headers': header, 'envvars': envvars}
-    for arg in ['headers', 'envvars']:
-        if not kwargs[arg]:
-            kwargs.pop(arg)
+    if header:
+        envvars['headers'] = header
 
     try:
-        env = spag_files.SpagEnvironment().set_env(kwargs)
+        env = spag_files.SpagEnvironment().set_env(envvars)
         click.echo(yaml.safe_dump(env, default_flow_style=False))
     except ToughNoodles as e:
         click.echo(str(e), err=True)

--- a/tests/test_spag.py
+++ b/tests/test_spag.py
@@ -97,8 +97,8 @@ class TestGet(BaseTest):
         self.assertEqual(json.loads(out), {"token": "abcde"})
 
     def test_get_presupply_endpoint(self):
-        out, err, ret = run_spag('env', 'set', '-E', 'endpoint=%s' % ENDPOINT)
-        self.assertEqual(out, 'envvars:\n  endpoint: {0}\n\n'.format(ENDPOINT))
+        out, err, ret = run_spag('env', 'set', 'endpoint=%s' % ENDPOINT)
+        self.assertEqual(out, 'endpoint: {0}\n\n'.format(ENDPOINT))
         self.assertEqual(err, '')
         self.assertEqual(ret, 0)
         out, err, ret = run_spag('get', '/things')
@@ -109,7 +109,7 @@ class TestGet(BaseTest):
 class TestPost(BaseTest):
 
     def test_spag_post(self):
-        run_spag('env', 'set', '-E', 'endpoint=%s' % ENDPOINT)
+        run_spag('env', 'set', 'endpoint=%s' % ENDPOINT)
         out, err, ret = run_spag('post', '/things', '--data', '{"id": "a"}',
                                  '-H', 'content-type:application/json')
         self.assertEquals(ret, 0)
@@ -119,7 +119,7 @@ class TestPost(BaseTest):
 class TestPut(BaseTest):
 
     def test_spag_put(self):
-        run_spag('env', 'set', '-E', 'endpoint=%s' % ENDPOINT)
+        run_spag('env', 'set', 'endpoint=%s' % ENDPOINT)
         out, err, ret = run_spag('post', '/things', '--data', '{"id": "a"}',
                                  '-H', 'content-type:application/json')
         self.assertEquals(ret, 0)
@@ -134,7 +134,7 @@ class TestPut(BaseTest):
 class TestPatch(BaseTest):
 
     def test_spag_patch(self):
-        run_spag('env', 'set', '-E', 'endpoint=%s' % ENDPOINT)
+        run_spag('env', 'set', 'endpoint=%s' % ENDPOINT)
         out, err, ret = run_spag('post', '/things', '--data', '{"id": "a"}',
                                  '-H', 'content-type:application/json')
         self.assertEquals(ret, 0)
@@ -149,7 +149,7 @@ class TestPatch(BaseTest):
 class TestDelete(BaseTest):
 
     def test_spag_delete(self):
-        run_spag('env', 'set', '-E', 'endpoint=%s' % ENDPOINT)
+        run_spag('env', 'set', 'endpoint=%s' % ENDPOINT)
         out, err, ret = run_spag('post', '/things', '--data', '{"id": "a"}',
                                  '-H', 'content-type:application/json')
         self.assertEquals(ret, 0)
@@ -169,8 +169,8 @@ class TestSpagFiles(BaseTest):
 
     def setUp(self):
         super(TestSpagFiles, self).setUp()
-        run_spag('env', 'set', '-E', 'endpoint=%s' % ENDPOINT)
-        run_spag('env', 'set', '-E', 'dir=%s' % RESOURCES_DIR)
+        run_spag('env', 'set', 'endpoint=%s' % ENDPOINT)
+        run_spag('env', 'set', 'dir=%s' % RESOURCES_DIR)
         self.table = spag_files.SpagFilesLookup(RESOURCES_DIR)
 
     def test_spag_lookup(self):
@@ -279,7 +279,7 @@ class TestSpagFiles(BaseTest):
         self.assertEqual(ret, 0)
 
     def test_spag_environment_crud(self):
-        out, err, ret = run_spag('env', 'set', '-E', 'endpoint=abcdefgh')
+        out, err, ret = run_spag('env', 'set', 'endpoint=abcdefgh')
         self.assertIn('endpoint: abcdefgh', out)
         self.assertEqual(err, '')
         self.assertEqual(ret, 0)
@@ -303,7 +303,7 @@ class TestSpagFiles(BaseTest):
         self.assertEqual(err, '')
         self.assertEqual(ret, 0)
 
-        out, err, ret = run_spag('env', 'set', '-E', 'endpoint=abcdefgh')
+        out, err, ret = run_spag('env', 'set', 'endpoint=abcdefgh')
         self.assertIn('endpoint: abcdefgh', out)
         self.assertEqual(err, '')
         self.assertEqual(ret, 0)
@@ -323,7 +323,7 @@ class TestSpagFiles(BaseTest):
         self.assertNotEqual(ret, 0)
 
     def test_set_endoint_and_header(self):
-        out, err, ret = run_spag('env', 'set', '-E', 'endpoint=%s' % ENDPOINT, '-H', 'pglbutt:pglbutt')
+        out, err, ret = run_spag('env', 'set', 'endpoint=%s' % ENDPOINT, '-H', 'pglbutt:pglbutt')
         self.assertEqual(err, '')
         self.assertEqual(ret, 0)
         self.assertIn('headers', out)
@@ -336,7 +336,7 @@ class TestSpagRemembers(BaseTest):
 
     def setUp(self):
         super(TestSpagRemembers, self).setUp()
-        run_spag('env', 'set', '-E', 'endpoint=%s' % ENDPOINT)
+        run_spag('env', 'set', 'endpoint=%s' % ENDPOINT)
 
     def test_spag_remembers_request(self):
         auth_file = os.path.join(SPAG_REMEMBERS_DIR, 'v2/post_thing.yml')
@@ -406,8 +406,8 @@ class TestSpagTemplate(BaseTest):
 
     def setUp(self):
         super(TestSpagTemplate, self).setUp()
-        assert run_spag('env', 'set', '-E', 'endpoint=%s' % ENDPOINT)[2] == 0
-        assert run_spag('env', 'set', '-E', 'dir=%s' % TEMPLATES_DIR)
+        assert run_spag('env', 'set', 'endpoint=%s' % ENDPOINT)[2] == 0
+        assert run_spag('env', 'set', 'dir=%s' % TEMPLATES_DIR)
 
     def test_spag_template_with_keyword(self):
         out, err, ret = run_spag('request', 'templates/post_thing',


### PR DESCRIPTION
Setting env vars is now
`spag env set endpoint=poo foo=bar`
Environment files are now strucutured
```
endpoint: foo
headers:
    content-type:application/json
foo: baz
```