### PR TITLE
Support default values in template lists

### DIFF
--- a/tests/templates/get_default.yml
+++ b/tests/templates/get_default.yml
@@ -1,0 +1,5 @@
+method: GET
+uri: /things/{{thing_id, other_thing_id : mydefaultid}}
+headers:
+    Content-Type: "application/json"
+    Accept: "application/json"

--- a/tests/test_spag.py
+++ b/tests/test_spag.py
@@ -590,3 +590,14 @@ class TestSpagHistory(BaseTest):
         self.assertEqual(err, '')
         self.assertIn('POST %s/things' % ENDPOINT, out)
         self.assertEqual(ret, 0)
+
+    def test_spag_template_default(self):
+        _, err, ret = run_spag('request', 'template/post_thing',
+                               '--with', 'thing_id=mydefaultid')
+        self.assertEqual(err, '')
+        self.assertEqual(ret, 0)
+
+        out, err, ret = run_spag('request', 'template/get_default')
+        self.assertEqual(err, '')
+        self.assertEqual(json.loads(out), {"id": "mydefaultid"})
+        self.assertEqual(ret, 0)


### PR DESCRIPTION
We can now use a colon to specify the default value in a template list

    {{item1, item2}}            <-- without default
    {{item1, item2 : default}}  <-- with default
    {{:default}}                <-- this works
    {{item1 : }}                <-- invalid
    {{:}}                       <-- invalid

closes #28 