### PR TITLE
Print out some helpful information on error

### DIFF
--- a/spag.py
+++ b/spag.py
@@ -28,7 +28,11 @@ def show_response(resp, show_headers):
     if show_headers:
         for k, v in resp.headers.items():
             click.echo("{0}: {1}".format(k, v))
-    click.echo(resp.text)
+    if resp.ok:
+        click.echo(resp.text)
+    else:
+        click.echo("ERROR: %s %s" % (str(resp.status_code), resp.reason))
+        click.echo(resp.text)
 
 @cli.command('get')
 @click.argument('resource')


### PR DESCRIPTION
With this, when you get a 404, or some other error,
it prints out the error, along with the response if there is any.

For example
```
(venv)tim@ubuntu:~/repos/noodles$ spag get /things/poopy
ERROR: 404 NOT FOUND

```
fixes #39