### PR TITLE
Templates now work with environments

### DIFF
--- a/spag/files.py
+++ b/spag/files.py
@@ -120,7 +120,7 @@ class SpagEnvironment(object):
         try:
             env = load_file(filename)
         except Exception as e:
-            raise ToughNoodles(e.message)
+            raise ToughNoodles(str(e))
 
         active = os.path.join(cls.SPAG_ENV_DIR, 'active')
         f = open(active, 'w')
@@ -141,7 +141,7 @@ class SpagEnvironment(object):
             try:
                 return load_file(filename)
             except Exception as e:
-                raise ToughNoodles(e.msg)
+                raise ToughNoodles(str(e))
 
         # If there is no environment, activate the default one
         activename = os.path.join(cls.SPAG_ENV_DIR, 'active')

--- a/spag/template.py
+++ b/spag/template.py
@@ -202,7 +202,7 @@ def _lookup_item_from_request(item, body_type):
     return _dict_path_lookup(data, lookup_path)
 
 # allow brackets for specifying environment names
-VALID_SHORTCUT_CHARS = string.ascii_letters + string.digits + "[_."
+VALID_SHORTCUT_CHARS = string.ascii_letters + string.digits + "[]_."
 def _substitute_shortcuts(s, body_type):
     assert s.startswith('@')
     original = s

--- a/spag/template.py
+++ b/spag/template.py
@@ -7,25 +7,35 @@ Basic rules:
     - Attempt to produce a value by evaluating each item in the list, in order.
     - The entire text "{{...}}" is replaced with the first item that
     successfully yields a value.
-    - Items are evaulated as follows:
-        - If the item does not contain a '.' then the value is specified using
-        the `--with` option:
-            e.g. "{{thing_id}}" and "--with thing_id=poo" evaluates to "poo"
-        - If the item contains a period, then the value is found in a
-        remembered request file
-            e.g. "{{last.response.body.id}}" says to look in a file last.yml
-            and find the value keyed by response.body.id
+    - Each item in the list is evaluated as follows:
+        1. Grabbing data from environments
+            - "{{[env].headers.accept}}" says to lookup "headers.accept" in the
+            environment "env.yml"
+            - "{{[].headers.accept}}" says to lookup "headers.accept" in the
+            active environment
+        2. Grabbing data from requests
+            - "{{post.response.body.id}}" says to lookup "response.body.id" in
+            the request "post.yml"
+            - We know to grab data from a request file if no env is specified
+            and there is a '.' in the item
+        3. Grabbing data from `--with` options
+            - "{{thing_id}}" and "--with thing_id=poo" evaluates to "poo"
+            - We know to look in the with parameters if there is no environment
+            specified and there is no '.' in the item
 
 Default values:
 
     - A default value can be specified using a colon:
         {{item1, item2 : default}}
+    - This must be at the end of the list
     - If no items are matched, then the text after the colon is used
     - Whitespace surrounding the colon is ignored
 
 Shortcut rules:
 
     - Double exclamation point:
+        - If <expr> starts with "[env]" then @<expr> expands to {{[env]...}
+            @[env].headers.accept --> {{[env].headers.accept}}
         - If <expr> does not contain a '.', then @<expr> expands to
         {{last.response.body.<expr>}}.
             /thing/@id --> /thing/{{last.response.body.id}}
@@ -52,6 +62,21 @@ def _find_double_braces(s):
     if j < 0:
         raise common.ToughNoodles("Unclosed braces: '{0}'".format(s[i:i+20]))
     return i, j + 2
+
+def _read_environment_name(s):
+    """Return (name, end) such that s[:end] == "[<name>]". name may be empty.
+
+    Raises ToughNoodles on a dangling bracket, or if no bracket is found.
+    """
+    if not s:
+        raise Exception("BUG: _read_environment_name should never receive an "
+                        "empty string")
+    if s[0] != '[':
+        raise common.ToughNoodles("No brackets found in '{0}'".format(s))
+    end = s.find(']')
+    if end < 0:
+        raise common.ToughNoodles("Unclosed bracket: '{0}'".format(s))
+    return s[1:end], end + 1
 
 def _substitute_braces(s, withs, body_type):
     """Replace a string "{{...}}" with a value. Raises ToughNoodles on bad
@@ -93,26 +118,71 @@ def _substitute_braces(s, withs, body_type):
                 .format(original))
 
     for item in items:
-        # items without a dot are specfied using `--with item=val`
-        if '.' not in item and item in withs:
+        if item.startswith('['):
+            try:
+                return _lookup_item_from_environment(item)
+            except common.ToughNoodles:
+                pass
+        elif '.' in item:
+            try:
+                return _lookup_item_from_request(item, body_type)
+            except common.ToughNoodles:
+                pass
+        elif item in withs:
             return withs[item]
-        elif '.' not in item:
-            continue
 
-        try:
-            return _lookup_item_with_dot(item, body_type)
-        except common.ToughNoodles:
-            pass
-
+    # haven't found a value yet. try returning the default.
     if default is not None:
         return default
 
     raise common.ToughNoodles("Failed to substitute for {0}".format(original))
 
-def _lookup_item_with_dot(item, body_type):
+def _dict_path_lookup(data, path):
+    """If path == "a.b.c", return data['a']['b']['c']. Raise ToughNoodles if
+    the value is not found.
+    """
+    path = path.strip('.').split('.')
+    try:
+        for key in path:
+            # TODO: do we care about this?
+            # this won't work if we have a list somewhere along the way:
+            #   data = {a: [{b: 1}, {b: 2}]}
+            #   path = "a.0.2"
+            # we'll do:
+            #   data = data['a']  # data == [{b: 1}, {b: 2}]
+            #   data = data['0']  # error, list needs integer indices
+            if key in data:
+                data = data[key]
+            else:
+                raise common.ToughNoodles
+        return data
+    except TypeError:
+        # raised if we tried LIST['poo'] or STRING['poo']
+        pass
+    except IndexError:
+        # raised if we tried LIST[999999999] or STRING[99999999]
+        pass
+    raise common.ToughNoodles
+
+def _lookup_item_from_environment(item):
+    name, end = _read_environment_name(item)
+    path = item[end:]
+    if not path:
+        raise common.ToughNoodles("No path found after [{0}]".format(item))
+
+    name = name.strip() or None
+
+    data = files.SpagEnvironment.get_env(name)
+    # all of the following produce the same thing with _dict_path_lookup...
+    #   "[env]poo"
+    #   "[env].poo"
+    #   "[env]...poo..."
+    return _dict_path_lookup(data, path)
+
+def _lookup_item_from_request(item, body_type):
     # for "thing.something.maybe.more", find thing.yml in the remembered files
-    parts = item.split('.')
-    name, lookup = parts[0], parts[1:]
+    parts = item.split('.', 1)
+    name, lookup_path = parts[0], parts[1]
 
     path = remembers.SpagRemembers().get_path(name)
     data = files.load_file(path)
@@ -129,53 +199,36 @@ def _lookup_item_with_dot(item, body_type):
             # failed to load json, but keep trying. maybe the user
             # doesn't need the json body.
 
-    # if lookup = ['a', 'b', 'c'] then we need data['a']['b']['c']
-    # print >>sys.stderr, data
-    try:
-        for key in lookup:
-            if key in data:
-                data = data[key]
-            else:
-                raise common.ToughNoodles
-        return data
-    except common.ToughNoodles:
-        pass
-    except TypeError:
-        # raised if we tried LIST['poo'] or STRING['poo']
-        pass
-    except IndexError:
-        # raised if we tried LIST[999999999] or STRING[99999999]
-        pass
+    return _dict_path_lookup(data, lookup_path)
 
-    raise common.ToughNoodles
-
-VALID_BANG_CHARS = string.ascii_letters + string.digits + "_."
-def _substitute_bangs(s, body_type):
+# allow brackets for specifying environment names
+VALID_SHORTCUT_CHARS = string.ascii_letters + string.digits + "[_."
+def _substitute_shortcuts(s, body_type):
     assert s.startswith('@')
     original = s
     s = s[len('@'):]
     if not s:
         raise common.ToughNoodles("No key found after @")
-    if s[0] not in VALID_BANG_CHARS:
+    if s[0] not in VALID_SHORTCUT_CHARS:
         raise common.ToughNoodles("Invalid char '{0}' found immediately after @"
-                           .format(s[0]))
+                                  .format(s[0]))
 
     count = 0
     for c in s:
-        if c not in VALID_BANG_CHARS:
+        if c not in VALID_SHORTCUT_CHARS:
             break
         count += 1
 
     # in case we have '@....poo', just compress the dots into a single dot
     key = s[:count].strip('.')
-
-    if '.' in key:
+    if key.startswith('['):
+        return _lookup_item_from_environment(key)
+    elif '.' in key:
         key = 'last.response.' + key
+        return _lookup_item_from_request(key, body_type)
     else:
         key = 'last.response.body.' + key
-
-    return _lookup_item_with_dot(key, body_type) + s[count:]
-
+        return _lookup_item_from_request(key, body_type)
 
 def untemplate(s, withs={}, body_type='json', shortcuts=False):
     """Process the {{ }} sections of the template strings
@@ -195,7 +248,7 @@ def untemplate(s, withs={}, body_type='json', shortcuts=False):
             i = s.find('@')
             if i < 0:
                 break
-            s = s[:i] + _substitute_bangs(s[i:], body_type)
+            s = s[:i] + _substitute_shortcuts(s[i:], body_type)
     return s
 
 def split_with(w):

--- a/tests/templates/get_active_env.yml
+++ b/tests/templates/get_active_env.yml
@@ -1,0 +1,6 @@
+method: GET
+uri: /headers
+headers:
+    mini: {{[].mini}}
+    wumbo: {{other, [].wumbo}}
+    thing: {{other, [].thing, last.request.body.id}}

--- a/tests/templates/get_default_env.yml
+++ b/tests/templates/get_default_env.yml
@@ -1,0 +1,6 @@
+method: GET
+uri: /headers
+headers:
+    mini: {{[default].mini}}
+    wumbo: {{other, [default].wumbo}}
+    thing: {{other, [default].thing, last.request.body.id}}

--- a/tests/test_spag.py
+++ b/tests/test_spag.py
@@ -33,6 +33,9 @@ def run_spag(*args):
 
 class BaseTest(unittest.TestCase):
 
+    # enable long diffs
+    maxDiff = None
+
     @classmethod
     def _rm_remembers_dir(cls):
         try:
@@ -514,6 +517,41 @@ class TestSpagTemplate(BaseTest):
         self.assertEqual(json.loads(out), {"id": "wumbo"})
         self.assertEqual(ret, 0)
 
+    def test_spag_template_default(self):
+        _, err, ret = run_spag('request', 'template/post_thing',
+                               '--with', 'thing_id=mydefaultid')
+        self.assertEqual(err, '')
+        self.assertEqual(ret, 0)
+
+        out, err, ret = run_spag('request', 'template/get_default')
+        self.assertEqual(err, '')
+        self.assertEqual(json.loads(out), {"id": "mydefaultid"})
+        self.assertEqual(ret, 0)
+
+    def test_spag_template_from_default_and_active_environments(self):
+        _, err, ret = run_spag('env', 'set',
+                               'mini=barnacle boy',
+                               'wumbo=mermaid man',
+                               'thing=scooby doo')
+        self.assertEqual(err, '')
+        self.assertEqual(ret, 0)
+
+        out, err, ret = run_spag('request', 'templates/get_default_env.yml')
+        self.assertEqual(err, '')
+        self.assertEqual(json.loads(out),
+            { "Mini": "barnacle boy",
+              "Wumbo": "mermaid man",
+              "Thing": "scooby doo" })
+        self.assertEqual(ret, 0)
+
+        out, err, ret = run_spag('request', 'templates/get_active_env.yml')
+        self.assertEqual(err, '')
+        self.assertEqual(json.loads(out),
+            { "Mini": "barnacle boy",
+              "Wumbo": "mermaid man",
+              "Thing": "scooby doo" })
+        self.assertEqual(ret, 0)
+
 
 class TestSpagHistory(BaseTest):
 
@@ -566,7 +604,6 @@ class TestSpagHistory(BaseTest):
 
     def test_multi_history_items(self):
         # make three requests
-        self.maxDiff = 9999999
         _, err, _ = run_spag('get', '/things')
         self.assertEqual(err, '')
         _, err, _ = run_spag('request', 'template/post_thing',
@@ -591,13 +628,3 @@ class TestSpagHistory(BaseTest):
         self.assertIn('POST %s/things' % ENDPOINT, out)
         self.assertEqual(ret, 0)
 
-    def test_spag_template_default(self):
-        _, err, ret = run_spag('request', 'template/post_thing',
-                               '--with', 'thing_id=mydefaultid')
-        self.assertEqual(err, '')
-        self.assertEqual(ret, 0)
-
-        out, err, ret = run_spag('request', 'template/get_default')
-        self.assertEqual(err, '')
-        self.assertEqual(json.loads(out), {"id": "mydefaultid"})
-        self.assertEqual(ret, 0)

--- a/tests/test_spag.py
+++ b/tests/test_spag.py
@@ -552,6 +552,18 @@ class TestSpagTemplate(BaseTest):
               "Thing": "scooby doo" })
         self.assertEqual(ret, 0)
 
+    def test_spag_template_shortcut_from_default_environment(self):
+        _, err, ret = run_spag('request', 'template/post_thing',
+                               '--with', 'thing_id=wumbo')
+        self.assertEqual(err, '')
+        self.assertEqual(ret, 0)
+
+        # set thing_id and lookup thing_id in the env using shortcut syntax
+        run_spag('env', 'set', 'thing_id=wumbo')
+        out, err, ret = run_spag('get', '/things/@[default].thing_id')
+        self.assertEqual(err, '')
+        self.assertEqual(json.loads(out), { "id": "wumbo" })
+        self.assertEqual(ret, 0)
 
 class TestSpagHistory(BaseTest):
 


### PR DESCRIPTION
* "{{[env].thing}}" is the value keyed by 'thing' in "env.yml"
* "@[env].thing" is the equivalent shortcut syntax
* Use str(e) instead of e.message for 2/3 compatibility

resolves #43 