### PR TITLE
Improve templates

### DIFF
--- a/spag/cli.py
+++ b/spag/cli.py
@@ -138,7 +138,7 @@ def request(dir=None, name=None, endpoint=None, data=None, header=None,
             req = yaml.safe_load(raw)
 
             if header:
-                header = {k: template.untemplate(v, shortcuts=True) for k, v in header}
+                header = {k: template.untemplate(v, shortcuts=True) for k, v in header.items()}
             kwargs = {
                 'url': endpoint + req['uri'],
                 'headers': header or req.get('headers', {})

--- a/spag/cli.py
+++ b/spag/cli.py
@@ -41,6 +41,8 @@ def get(resource, endpoint=None, data=None, header=None, show_headers=False):
     """HTTP GET"""
     uri = endpoint + resource
     uri = template.untemplate(uri, shortcuts=True)
+    if data: data = template.untemplate(data, shortcuts=True)
+    if header: header = {k: template.untemplate(v, shortcuts=True) for k, v in header.items()}
     r = requests.get(uri, headers=header, data=data)
     show_response(r, show_headers)
     remembers.SpagRemembers.remember_request('get', r)
@@ -53,6 +55,8 @@ def post(resource, endpoint=None, data=None, header=None, show_headers=False):
     """HTTP POST"""
     uri = endpoint + resource
     uri = template.untemplate(uri, shortcuts=True)
+    if data: data = template.untemplate(data, shortcuts=True)
+    if header: header = {k: template.untemplate(v, shortcuts=True) for k, v in header.items()}
     r = requests.post(uri, data=data, headers=header)
     show_response(r, show_headers)
     remembers.SpagRemembers.remember_request('post', r)
@@ -65,6 +69,8 @@ def put(resource, endpoint=None, data=None, header=None, show_headers=False):
     """HTTP PUT"""
     uri = endpoint + resource
     uri = template.untemplate(uri, shortcuts=True)
+    if data: data = template.untemplate(data, shortcuts=True)
+    if header: header = {k: template.untemplate(v, shortcuts=True) for k, v in header.items()}
     r = requests.put(uri, data=data, headers=header)
     show_response(r, show_headers)
     remembers.SpagRemembers.remember_request('put', r)
@@ -77,6 +83,8 @@ def patch(resource, endpoint=None, data=None, header=None, show_headers=False):
     """HTTP PATCH"""
     uri = endpoint + resource
     uri = template.untemplate(uri, shortcuts=True)
+    if data: data = template.untemplate(data, shortcuts=True)
+    if header: header = {k: template.untemplate(v, shortcuts=True) for k, v in header.items()}
     r = requests.patch(uri, data=data, headers=header)
     show_response(r, show_headers)
     remembers.SpagRemembers.remember_request('patch', r)
@@ -89,6 +97,8 @@ def delete(resource, endpoint=None, data=None, header=None, show_headers=False):
     """HTTP DELETE"""
     uri = endpoint + resource
     uri = template.untemplate(uri, shortcuts=True)
+    if data: data = template.untemplate(data, shortcuts=True)
+    if header: header = {k: template.untemplate(v, shortcuts=True) for k, v in header.items()}
     r = requests.delete(uri, data=data, headers=header)
     show_response(r, show_headers)
     remembers.SpagRemembers.remember_request('delete', r)
@@ -127,12 +137,14 @@ def request(dir=None, name=None, endpoint=None, data=None, header=None,
 
             req = yaml.safe_load(raw)
 
+            if header:
+                header = {k: template.untemplate(v, shortcuts=True) for k, v in header}
             kwargs = {
                 'url': endpoint + req['uri'],
                 'headers': header or req.get('headers', {})
             }
             if data is not None:
-                kwargs['data'] = data
+                kwargs['data'] = template.untemplate(data, shortcuts=True)
             elif 'body' in req:
                 kwargs['data'] = req['body']
 
@@ -191,8 +203,10 @@ def env_set(envvars=None, header=None):
         sys.exit(1)
 
     # Switch envvars, headers from Tuples to dict
-    envvars = {key: value for (key, value) in [e.split('=') for e in envvars]}
-    header = {key: value.strip() for (key, value) in [h.split(':') for h in header]}
+    envvars = {key: template.untemplate(value, shortcuts=True)
+               for (key, value) in [e.split('=') for e in envvars]}
+    header = {key: template.untemplate(value.strip(), shortcuts=True)
+              for (key, value) in [h.split(':') for h in header]}
 
     if header:
         envvars['headers'] = header

--- a/spag/decorators.py
+++ b/spag/decorators.py
@@ -4,7 +4,7 @@ import functools
 import click
 
 from spag import files
-from spag.common import ToughNoodles, update
+from spag.common import ToughNoodles
 
 def determine_endpoint(f):
     @functools.wraps(f)
@@ -23,34 +23,30 @@ def determine_endpoint(f):
         return f(*args, **kwargs)
     return wrapper
 
+def _headers_to_dict(headers):
+    if type(headers) != dict:
+        # assume something iterable, like tuple or list
+        return {key: value.strip()
+                for (key, value) in [h.split(':') for h in headers]}
+    return headers
+
 def prepare_headers(f):
     @functools.wraps(f)
     def wrapper(*args, **kwargs):
         env = files.SpagEnvironment.get_env()
-        header = kwargs['header']
-        if header is None or header == ():
-            try:
-                headers = env['headers']
-                kwargs['header'] = headers
-            except ToughNoodles:
-                kwargs['header'] = None
-            except KeyError:
-                kwargs['header'] = None
-        else:
-            try:
-                # Headers come in as a tuple ('Header:Content', 'Header:Content')
-                supplied_headers = {key: value.strip() for (key, value) in [h.split(':') for h in header]}
-                if 'headers' in env:
-                    headers = update(env['headers'], supplied_headers)
-                else:
-                    headers = supplied_headers
-                kwargs['header'] = headers
-            except ValueError:
-                click.echo("Error: Invalid header!", err=True)
-                sys.exit(1)
-            except KeyError:
-                kwargs['header'] = {key: value.strip() for (key, value) in [h.split(':') for h in header]}
-
+        try:
+            if 'headers' in env:
+                # should already be a dict...
+                env['headers'] = _headers_to_dict(env['headers'])
+            if 'header' in kwargs:
+                kwargs['header'] = _headers_to_dict(kwargs['header'])
+                kwargs['header'].update(env.get('headers', {}))
+            else:
+                kwargs['header'] = dict(env.get('headers', {}))
+        except ValueError:
+            click.echo("Error: Invalid header!", err=True)
+            sys.exit(1)
+        assert type(kwargs['header']) is dict
         return f(*args, **kwargs)
     return wrapper
 

--- a/spag/decorators.py
+++ b/spag/decorators.py
@@ -35,14 +35,13 @@ def prepare_headers(f):
     def wrapper(*args, **kwargs):
         env = files.SpagEnvironment.get_env()
         try:
-            if 'headers' in env:
-                # should already be a dict...
-                env['headers'] = _headers_to_dict(env['headers'])
+            env['headers'] = _headers_to_dict(env.get('headers', {}))
             if 'header' in kwargs:
-                kwargs['header'] = _headers_to_dict(kwargs['header'])
-                kwargs['header'].update(env.get('headers', {}))
+                kwargs_headers = _headers_to_dict(kwargs['header'])
+                kwargs['header'] = env['headers']
+                kwargs['header'].update(kwargs_headers)
             else:
-                kwargs['header'] = dict(env.get('headers', {}))
+                kwargs['header'] = env['headers']
         except ValueError:
             click.echo("Error: Invalid header!", err=True)
             sys.exit(1)

--- a/spag/files.py
+++ b/spag/files.py
@@ -120,7 +120,7 @@ class SpagEnvironment(object):
         try:
             env = load_file(filename)
         except Exception as e:
-            raise ToughNoodles(e.message)
+            raise ToughNoodles(str(e))
 
         active = os.path.join(cls.SPAG_ENV_DIR, 'active')
         f = open(active, 'w')
@@ -141,7 +141,7 @@ class SpagEnvironment(object):
             try:
                 return load_file(filename)
             except Exception as e:
-                raise ToughNoodles(e.msg)
+                raise ToughNoodles(str(e))
 
         # If there is no environment, activate the default one
         activename = os.path.join(cls.SPAG_ENV_DIR, 'active')

--- a/spag/template.py
+++ b/spag/template.py
@@ -202,7 +202,7 @@ def _lookup_item_from_request(item, body_type):
     return _dict_path_lookup(data, lookup_path)
 
 # allow brackets for specifying environment names
-VALID_SHORTCUT_CHARS = string.ascii_letters + string.digits + "[_."
+VALID_SHORTCUT_CHARS = string.ascii_letters + string.digits + "[]_."
 def _substitute_shortcuts(s, body_type):
     assert s.startswith('@')
     original = s

--- a/spag/template.py
+++ b/spag/template.py
@@ -7,25 +7,35 @@ Basic rules:
     - Attempt to produce a value by evaluating each item in the list, in order.
     - The entire text "{{...}}" is replaced with the first item that
     successfully yields a value.
-    - Items are evaulated as follows:
-        - If the item does not contain a '.' then the value is specified using
-        the `--with` option:
-            e.g. "{{thing_id}}" and "--with thing_id=poo" evaluates to "poo"
-        - If the item contains a period, then the value is found in a
-        remembered request file
-            e.g. "{{last.response.body.id}}" says to look in a file last.yml
-            and find the value keyed by response.body.id
+    - Each item in the list is evaluated as follows:
+        1. Grabbing data from environments
+            - "{{[env].headers.accept}}" says to lookup "headers.accept" in the
+            environment "env.yml"
+            - "{{[].headers.accept}}" says to lookup "headers.accept" in the
+            active environment
+        2. Grabbing data from requests
+            - "{{post.response.body.id}}" says to lookup "response.body.id" in
+            the request "post.yml"
+            - We know to grab data from a request file if no env is specified
+            and there is a '.' in the item
+        3. Grabbing data from `--with` options
+            - "{{thing_id}}" and "--with thing_id=poo" evaluates to "poo"
+            - We know to look in the with parameters if there is no environment
+            specified and there is no '.' in the item
 
 Default values:
 
     - A default value can be specified using a colon:
         {{item1, item2 : default}}
+    - This must be at the end of the list
     - If no items are matched, then the text after the colon is used
     - Whitespace surrounding the colon is ignored
 
 Shortcut rules:
 
     - Double exclamation point:
+        - If <expr> starts with "[env]" then @<expr> expands to {{[env]...}
+            @[env].headers.accept --> {{[env].headers.accept}}
         - If <expr> does not contain a '.', then @<expr> expands to
         {{last.response.body.<expr>}}.
             /thing/@id --> /thing/{{last.response.body.id}}
@@ -52,6 +62,21 @@ def _find_double_braces(s):
     if j < 0:
         raise common.ToughNoodles("Unclosed braces: '{0}'".format(s[i:i+20]))
     return i, j + 2
+
+def _read_environment_name(s):
+    """Return (name, end) such that s[:end] == "[<name>]". name may be empty.
+
+    Raises ToughNoodles on a dangling bracket, or if no bracket is found.
+    """
+    if not s:
+        raise Exception("BUG: _read_environment_name should never receive an "
+                        "empty string")
+    if s[0] != '[':
+        raise common.ToughNoodles("No brackets found in '{0}'".format(s))
+    end = s.find(']')
+    if end < 0:
+        raise common.ToughNoodles("Unclosed bracket: '{0}'".format(s))
+    return s[1:end], end + 1
 
 def _substitute_braces(s, withs, body_type):
     """Replace a string "{{...}}" with a value. Raises ToughNoodles on bad
@@ -93,26 +118,71 @@ def _substitute_braces(s, withs, body_type):
                 .format(original))
 
     for item in items:
-        # items without a dot are specfied using `--with item=val`
-        if '.' not in item and item in withs:
+        if item.startswith('['):
+            try:
+                return _lookup_item_from_environment(item)
+            except common.ToughNoodles:
+                pass
+        elif '.' in item:
+            try:
+                return _lookup_item_from_request(item, body_type)
+            except common.ToughNoodles:
+                pass
+        elif item in withs:
             return withs[item]
-        elif '.' not in item:
-            continue
 
-        try:
-            return _lookup_item_with_dot(item, body_type)
-        except common.ToughNoodles:
-            pass
-
+    # haven't found a value yet. try returning the default.
     if default is not None:
         return default
 
     raise common.ToughNoodles("Failed to substitute for {0}".format(original))
 
-def _lookup_item_with_dot(item, body_type):
+def _dict_path_lookup(data, path):
+    """If path == "a.b.c", return data['a']['b']['c']. Raise ToughNoodles if
+    the value is not found.
+    """
+    path = path.strip('.').split('.')
+    try:
+        for key in path:
+            # TODO: do we care about this?
+            # this won't work if we have a list somewhere along the way:
+            #   data = {a: [{b: 1}, {b: 2}]}
+            #   path = "a.0.2"
+            # we'll do:
+            #   data = data['a']  # data == [{b: 1}, {b: 2}]
+            #   data = data['0']  # error, list needs integer indices
+            if key in data:
+                data = data[key]
+            else:
+                raise common.ToughNoodles
+        return data
+    except TypeError:
+        # raised if we tried LIST['poo'] or STRING['poo']
+        pass
+    except IndexError:
+        # raised if we tried LIST[999999999] or STRING[99999999]
+        pass
+    raise common.ToughNoodles
+
+def _lookup_item_from_environment(item):
+    name, end = _read_environment_name(item)
+    path = item[end:]
+    if not path:
+        raise common.ToughNoodles("No path found after [{0}]".format(item))
+
+    name = name.strip() or None
+
+    data = files.SpagEnvironment.get_env(name)
+    # all of the following produce the same thing with _dict_path_lookup...
+    #   "[env]poo"
+    #   "[env].poo"
+    #   "[env]...poo..."
+    return _dict_path_lookup(data, path)
+
+def _lookup_item_from_request(item, body_type):
     # for "thing.something.maybe.more", find thing.yml in the remembered files
-    parts = item.split('.')
-    name, lookup = parts[0], parts[1:]
+    parts = item.split('.', 1)
+    name, lookup_path = parts[0], parts[1]
 
     path = remembers.SpagRemembers().get_path(name)
     data = files.load_file(path)
@@ -129,53 +199,36 @@ def _lookup_item_with_dot(item, body_type):
             # failed to load json, but keep trying. maybe the user
             # doesn't need the json body.
 
-    # if lookup = ['a', 'b', 'c'] then we need data['a']['b']['c']
-    # print >>sys.stderr, data
-    try:
-        for key in lookup:
-            if key in data:
-                data = data[key]
-            else:
-                raise common.ToughNoodles
-        return data
-    except common.ToughNoodles:
-        pass
-    except TypeError:
-        # raised if we tried LIST['poo'] or STRING['poo']
-        pass
-    except IndexError:
-        # raised if we tried LIST[999999999] or STRING[99999999]
-        pass
+    return _dict_path_lookup(data, lookup_path)
 
-    raise common.ToughNoodles
-
-VALID_BANG_CHARS = string.ascii_letters + string.digits + "_."
-def _substitute_bangs(s, body_type):
+# allow brackets for specifying environment names
+VALID_SHORTCUT_CHARS = string.ascii_letters + string.digits + "[_."
+def _substitute_shortcuts(s, body_type):
     assert s.startswith('@')
     original = s
     s = s[len('@'):]
     if not s:
         raise common.ToughNoodles("No key found after @")
-    if s[0] not in VALID_BANG_CHARS:
+    if s[0] not in VALID_SHORTCUT_CHARS:
         raise common.ToughNoodles("Invalid char '{0}' found immediately after @"
-                           .format(s[0]))
+                                  .format(s[0]))
 
     count = 0
     for c in s:
-        if c not in VALID_BANG_CHARS:
+        if c not in VALID_SHORTCUT_CHARS:
             break
         count += 1
 
     # in case we have '@....poo', just compress the dots into a single dot
     key = s[:count].strip('.')
-
-    if '.' in key:
+    if key.startswith('['):
+        return _lookup_item_from_environment(key)
+    elif '.' in key:
         key = 'last.response.' + key
+        return _lookup_item_from_request(key, body_type)
     else:
         key = 'last.response.body.' + key
-
-    return _lookup_item_with_dot(key, body_type) + s[count:]
-
+        return _lookup_item_from_request(key, body_type)
 
 def untemplate(s, withs={}, body_type='json', shortcuts=False):
     """Process the {{ }} sections of the template strings
@@ -195,7 +248,7 @@ def untemplate(s, withs={}, body_type='json', shortcuts=False):
             i = s.find('@')
             if i < 0:
                 break
-            s = s[:i] + _substitute_bangs(s[i:], body_type)
+            s = s[:i] + _substitute_shortcuts(s[i:], body_type)
     return s
 
 def split_with(w):

--- a/spag/template.py
+++ b/spag/template.py
@@ -222,13 +222,14 @@ def _substitute_shortcuts(s, body_type):
     # in case we have '@....poo', just compress the dots into a single dot
     key = s[:count].strip('.')
     if key.startswith('['):
-        return _lookup_item_from_environment(key)
+        val = _lookup_item_from_environment(key)
     elif '.' in key:
         key = 'last.response.' + key
-        return _lookup_item_from_request(key, body_type)
+        val = _lookup_item_from_request(key, body_type)
     else:
         key = 'last.response.body.' + key
-        return _lookup_item_from_request(key, body_type)
+        val = _lookup_item_from_request(key, body_type)
+    return val + s[count:]
 
 def untemplate(s, withs={}, body_type='json', shortcuts=False):
     """Process the {{ }} sections of the template strings
@@ -258,4 +259,5 @@ def split_with(w):
     return parts
 
 def parse_withs(withs):
-    return {k: v for k, v in (split_with(w) for w in withs)}
+    return {k: untemplate(v, shortcuts=True)
+            for k, v in (split_with(w) for w in withs)}

--- a/tests/templates/get_active_env.yml
+++ b/tests/templates/get_active_env.yml
@@ -1,0 +1,6 @@
+method: GET
+uri: /headers
+headers:
+    mini: {{[].mini}}
+    wumbo: {{other, [].wumbo}}
+    thing: {{other, [].thing, last.request.body.id}}

--- a/tests/templates/get_default_env.yml
+++ b/tests/templates/get_default_env.yml
@@ -1,0 +1,6 @@
+method: GET
+uri: /headers
+headers:
+    mini: {{[default].mini}}
+    wumbo: {{other, [default].wumbo}}
+    thing: {{other, [default].thing, last.request.body.id}}

--- a/tests/test_spag.py
+++ b/tests/test_spag.py
@@ -5,6 +5,8 @@ import shutil
 import json
 import textwrap
 
+import yaml
+
 from spag import remembers
 from spag import files
 
@@ -616,6 +618,26 @@ class TestSpagTemplate(BaseTest):
         out, err, ret = run_spag('get', '/things/@body.things.poo.id')
         self.assertIn('Invalid list index poo while fetching response.body.things.poo.id', err)
         self.assertEqual(ret, 1)
+
+    def test_spag_templated_env_set(self):
+        # set a value we'll refer to in a template parameter
+        out, err, ret = run_spag('env', 'set', 'squidward=tentacle')
+        self.assertEqual(err, '')
+        self.assertEqual(ret, 0)
+        self.assertEqual(yaml.load(out).get('squidward'), 'tentacle')
+
+        # check we can use template params with regular environment variables
+        out, err, ret = run_spag('env', 'set', 'patrick=@[].squidward')
+        self.assertEqual(err, '')
+        self.assertEqual(ret, 0)
+        self.assertEqual(yaml.load(out).get('patrick'), 'tentacle')
+
+        # check we can use template params when setting headers in the env
+        out, err, ret = run_spag('env', 'set', '-H', 'sandy: @[].patrick')
+        self.assertEqual(err, '')
+        self.assertEqual(ret, 0)
+        self.assertEqual(yaml.load(out)['headers'].get('sandy'), 'tentacle')
+
 
 class TestSpagHistory(BaseTest):
 

--- a/tests/test_spag.py
+++ b/tests/test_spag.py
@@ -33,6 +33,9 @@ def run_spag(*args):
 
 class BaseTest(unittest.TestCase):
 
+    # enable long diffs
+    maxDiff = None
+
     @classmethod
     def _rm_remembers_dir(cls):
         try:
@@ -514,6 +517,41 @@ class TestSpagTemplate(BaseTest):
         self.assertEqual(json.loads(out), {"id": "wumbo"})
         self.assertEqual(ret, 0)
 
+    def test_spag_template_default(self):
+        _, err, ret = run_spag('request', 'template/post_thing',
+                               '--with', 'thing_id=mydefaultid')
+        self.assertEqual(err, '')
+        self.assertEqual(ret, 0)
+
+        out, err, ret = run_spag('request', 'template/get_default')
+        self.assertEqual(err, '')
+        self.assertEqual(json.loads(out), {"id": "mydefaultid"})
+        self.assertEqual(ret, 0)
+
+    def test_spag_template_from_default_and_active_environments(self):
+        _, err, ret = run_spag('env', 'set',
+                               'mini=barnacle boy',
+                               'wumbo=mermaid man',
+                               'thing=scooby doo')
+        self.assertEqual(err, '')
+        self.assertEqual(ret, 0)
+
+        out, err, ret = run_spag('request', 'templates/get_default_env.yml')
+        self.assertEqual(err, '')
+        self.assertEqual(json.loads(out),
+            { "Mini": "barnacle boy",
+              "Wumbo": "mermaid man",
+              "Thing": "scooby doo" })
+        self.assertEqual(ret, 0)
+
+        out, err, ret = run_spag('request', 'templates/get_active_env.yml')
+        self.assertEqual(err, '')
+        self.assertEqual(json.loads(out),
+            { "Mini": "barnacle boy",
+              "Wumbo": "mermaid man",
+              "Thing": "scooby doo" })
+        self.assertEqual(ret, 0)
+
 
 class TestSpagHistory(BaseTest):
 
@@ -566,7 +604,6 @@ class TestSpagHistory(BaseTest):
 
     def test_multi_history_items(self):
         # make three requests
-        self.maxDiff = 9999999
         _, err, _ = run_spag('get', '/things')
         self.assertEqual(err, '')
         _, err, _ = run_spag('request', 'template/post_thing',
@@ -591,13 +628,3 @@ class TestSpagHistory(BaseTest):
         self.assertIn('POST %s/things' % ENDPOINT, out)
         self.assertEqual(ret, 0)
 
-    def test_spag_template_default(self):
-        _, err, ret = run_spag('request', 'template/post_thing',
-                               '--with', 'thing_id=mydefaultid')
-        self.assertEqual(err, '')
-        self.assertEqual(ret, 0)
-
-        out, err, ret = run_spag('request', 'template/get_default')
-        self.assertEqual(err, '')
-        self.assertEqual(json.loads(out), {"id": "mydefaultid"})
-        self.assertEqual(ret, 0)

--- a/tests/test_spag.py
+++ b/tests/test_spag.py
@@ -552,6 +552,18 @@ class TestSpagTemplate(BaseTest):
               "Thing": "scooby doo" })
         self.assertEqual(ret, 0)
 
+    def test_spag_template_shortcut_from_default_environment(self):
+        _, err, ret = run_spag('request', 'template/post_thing',
+                               '--with', 'thing_id=wumbo')
+        self.assertEqual(err, '')
+        self.assertEqual(ret, 0)
+
+        # set thing_id and lookup thing_id in the env using shortcut syntax
+        run_spag('env', 'set', 'thing_id=wumbo')
+        out, err, ret = run_spag('get', '/things/@[default].thing_id')
+        self.assertEqual(err, '')
+        self.assertEqual(json.loads(out), { "id": "wumbo" })
+        self.assertEqual(ret, 0)
 
 class TestSpagHistory(BaseTest):
 

--- a/tests/test_spag.py
+++ b/tests/test_spag.py
@@ -99,6 +99,16 @@ class TestHeaders(BaseTest):
         self.assertEqual(ret, 0)
         self.assertIn('content-type: application/json', out)
 
+    def test_passed_headers_override_environment(self):
+        out, err, ret = run_spag('env', 'set', '-H', 'a: b')
+        self.assertEqual(err, '')
+        self.assertEqual(ret, 0)
+        self.assertEqual(yaml.load(out)['headers'].get('a'), 'b')
+
+        out, err, ret = run_spag('get', '/headers', '-e', ENDPOINT, '-H', 'a: c')
+        self.assertEqual(err, '')
+        self.assertEqual(ret, 0)
+        self.assertEqual(json.loads(out).get('A'), 'c')
 
 class TestGet(BaseTest):
 

--- a/tests/test_spag.py
+++ b/tests/test_spag.py
@@ -589,6 +589,34 @@ class TestSpagTemplate(BaseTest):
         self.assertEqual(json.loads(out), { "id": "wumbo" })
         self.assertEqual(ret, 0)
 
+    def test_spag_template_list_indexing(self):
+        # setup the last request to have a list in it
+        self._post_thing('mini')
+        _, err, ret = run_spag('get', '/things')
+
+        out, err, ret = run_spag('get', '/things/@body.things.0.id')
+        self.assertEqual(err, '')
+        self.assertEqual(json.loads(out), {"id": "mini"})
+        self.assertEqual(ret, 0)
+
+    def test_spag_template_list_index_out_of_bounds(self):
+        # setup the last request to have a list in it
+        self._post_thing('mini')
+        _, err, ret = run_spag('get', '/things')
+
+        out, err, ret = run_spag('get', '/things/@body.things.1.id')
+        self.assertIn('Index 1 out of bounds while looking up response.body.things.1.id', err)
+        self.assertEqual(ret, 1)
+
+    def test_spag_template_list_w_invalid_index(self):
+        # setup the last request to have a list in it
+        self._post_thing('mini')
+        _, err, ret = run_spag('get', '/things')
+
+        out, err, ret = run_spag('get', '/things/@body.things.poo.id')
+        self.assertIn('Invalid list index poo while fetching response.body.things.poo.id', err)
+        self.assertEqual(ret, 1)
+
 class TestSpagHistory(BaseTest):
 
     def setUp(self):


### PR DESCRIPTION
For requests, shortcuts work in `--with` values, in `-H` args, and in `--data` args.

Doesn't yet work with environment commands like `spag env set thing=@id`.