### PR TITLE
Build Request objects. No more requests lib.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
 click==4.0
-requests==2.6.2
 PyYAML==3.11


### PR DESCRIPTION
* Removing requests speeds spag up a bit:
    * `time python -c "import requests"` takes about 90 ms.
    * `time python -c "import urllib2"` takes about 40 ms.
    * The tests take about 20% less time (52 vs 42 seconds)
* Refactored the code to build a Request object. This gives us the
request information without needing to make the request, which will be
useful for print as curl, parsing from curl, etc.