### PR TITLE
Don't panic when can't connect

### DIFF
--- a/src/spag/main.rs
+++ b/src/spag/main.rs
@@ -209,7 +209,7 @@ fn spag_method(args: &Args) {
 
 fn do_request(req: &SpagRequest) {
     let mut handle = http::handle();
-    let resp = req.prepare(&mut handle).exec().unwrap();
+    let resp = try_error!(req.prepare(&mut handle).exec());
     println!("{}", String::from_utf8(resp.get_body().to_vec()).unwrap());
     try_error!(history::append(req, &resp));
     try_error!(remember::remember(req, &resp));

--- a/tests/test_spag.py
+++ b/tests/test_spag.py
@@ -141,6 +141,11 @@ class TestGet(BaseTest):
         self.assertEqual(ret, 0)
         self.assertEqual(json.loads(out), {"things": []})
 
+    def test_with_non_responsive_endpoint(self):
+        out, err, ret = run_spag('env', 'set', 'endpoint', '%s' % ENDPOINT)
+        out, err, ret = run_spag('get', '/things', '-e', 'http://localhost:poo')
+        self.assertEqual(ret, 1)
+        self.assertEqual(err, 'Couldn\'t connect to server\n')
 
 class TestPost(BaseTest):
 


### PR DESCRIPTION
* Gives a (somewhat) informative error message when spag can't connect

closes #64