### PR TITLE
Various fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,6 @@ script:
     - ". .venv/bin/activate"
     - "pip install -r tests/test-requirements.txt"
     - "python tests/testapp.py &"
-    - "nosetests -sv tests/"
+    - "export SPAG_TEST_EXE='./target/release/spag' && nosetests -sv tests/"
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,8 @@ language: rust
 rust: nightly
 script:
     - "sudo apt-get update && sudo apt-get install python-virtualenv"
-    - "cargo build --verbose"
-    - "cargo test --verbose"
+    - "cargo build --release --verbose"
+    - "cargo test --release --verbose"
     - "virtualenv .venv"
     - ". .venv/bin/activate"
     - "pip install -r tests/test-requirements.txt"

--- a/src/spag/args.rs
+++ b/src/spag/args.rs
@@ -26,10 +26,10 @@ Usage:
     spag env show [<environment>]
     spag env activate <environment>
     spag env deactivate
-    spag (get|post|put|patch|delete) <resource> [(-H <header>)...] [-e <endpoint>] [-d <data>] [(--with <key> <val>)...]
+    spag (get|post|put|patch|delete) <resource> [(-H <header>)...] [-e <endpoint>] [-d <data>] [(--with <key> <val>)...] [-v]
     spag request list [--dir <dir>]
     spag request show <file>
-    spag request <file> [(-H <header>)...] [-e <endpoint>] [-d <data>] [(--with <key> <val>)...] [--dir <dir>]
+    spag request <file> [-v] [(-H <header>)...] [-e <endpoint>] [-d <data>] [(--with <key> <val>)...] [--dir <dir>]
     spag history
     spag history show <index>
 
@@ -39,6 +39,7 @@ Options:
     -e, --endpoint <endpoint>   Supply the endpoint
     -d, --data <data>           Supply the request body
     -E, --everything            Unset an entire environment
+    -v, --verbose               Print out more of the request and response
     --dir <dir>                 The directory containing request files
 
 Arguments:

--- a/src/spag/args.rs
+++ b/src/spag/args.rs
@@ -26,10 +26,10 @@ Usage:
     spag env show [<environment>]
     spag env activate <environment>
     spag env deactivate
-    spag (get|post|put|patch|delete) <resource> [(-H <header>)...] [-e <endpoint>] [-d <data>] [(--with <key> <val>)...] [-v]
+    spag (get|post|put|patch|delete) <resource> [(-H <header>)...] [-e <endpoint>] [-d <data>] [(--with <key> <val>)...] [-v] [--remember-as <name>]
     spag request list [--dir <dir>]
     spag request show <file>
-    spag request <file> [-v] [(-H <header>)...] [-e <endpoint>] [-d <data>] [(--with <key> <val>)...] [--dir <dir>]
+    spag request <file> [-v] [(-H <header>)...] [-e <endpoint>] [-d <data>] [(--with <key> <val>)...] [--dir <dir>] [--remember-as <name>]
     spag history
     spag history show <index>
 
@@ -40,6 +40,7 @@ Options:
     -d, --data <data>           Supply the request body
     -E, --everything            Unset an entire environment
     -v, --verbose               Print out more of the request and response
+    -r, --remember-as <name>    Additionally, remember this request under the given name
     --dir <dir>                 The directory containing request files
 
 Arguments:

--- a/src/spag/main.rs
+++ b/src/spag/main.rs
@@ -159,7 +159,7 @@ fn spag_request_a_file(args: &Args) {
             let mut req = SpagRequest::new(request::method_from_str(&method), endpoint, uri);
             try_error!(req.add_headers(headers.iter()));
             req.set_body(body);
-            do_request(&req);
+            do_request(args, &req);
         },
         Err(msg) => { error!("{}", msg); }
     }
@@ -204,14 +204,21 @@ fn spag_method(args: &Args) {
 
     let body = try_error!(args::get_data(args));
     req.set_body(body);
-    do_request(&req);
+    do_request(args, &req);
 }
 
-fn do_request(req: &SpagRequest) {
+fn do_request(args: &Args, req: &SpagRequest) {
     let mut handle = http::handle();
     let resp = try_error!(req.prepare(&mut handle).exec());
-    println!("{}", String::from_utf8(resp.get_body().to_vec()).unwrap());
     try_error!(history::append(req, &resp));
     try_error!(remember::remember(req, &resp));
+
+    if args.flag_verbose {
+        let out = try_error!(history::get(&"0".to_string()));
+        println!("{}", out);
+    } else {
+        println!("{}", String::from_utf8(resp.get_body().to_vec()).unwrap());
+    }
+
 }
 

--- a/src/spag/main.rs
+++ b/src/spag/main.rs
@@ -211,7 +211,10 @@ fn do_request(args: &Args, req: &SpagRequest) {
     let mut handle = http::handle();
     let resp = try_error!(req.prepare(&mut handle).exec());
     try_error!(history::append(req, &resp));
-    try_error!(remember::remember(req, &resp));
+    try_error!(remember::remember(req, &resp, "last.yml"));
+    if !args.flag_remember_as.is_empty() {
+        try_error!(remember::remember(req, &resp, &args.flag_remember_as));
+    }
 
     if args.flag_verbose {
         let out = try_error!(history::get(&"0".to_string()));

--- a/src/spag/main.rs
+++ b/src/spag/main.rs
@@ -182,8 +182,12 @@ fn spag_request_list(args: &Args) {
 
     let current_dir = try_error!(std::env::current_dir());
     for file in yaml_files.iter() {
-        // relative_from() is unstable
-        println!("{}", file.relative_from(&current_dir).unwrap().to_str().unwrap());
+        if file.starts_with(&current_dir) {
+            // relative_from() is unstable
+            println!("{}", file.relative_from(&current_dir).unwrap().to_str().unwrap());
+        } else {
+            println!("{}", file.to_str().unwrap());
+        }
     }
 }
 

--- a/src/spag/remember.rs
+++ b/src/spag/remember.rs
@@ -12,10 +12,11 @@ use super::yaml_util;
 
 const REMEMBERS_DIR: &'static str = ".spag/remembers";
 
-pub fn remember(req: &SpagRequest, resp: &http::Response) -> Result<(), String> {
+pub fn remember(req: &SpagRequest, resp: &http::Response, remember_as: &str) -> Result<(), String> {
     file::ensure_dir_exists(REMEMBERS_DIR);
     let y = serialize(req, resp);
-    let output_file = Path::new(REMEMBERS_DIR).join("last.yml");
+    let name = file::ensure_extension(remember_as, ".yml");
+    let output_file = Path::new(REMEMBERS_DIR).join(name);
     yaml_util::dump_yaml_file(output_file.to_str().unwrap(), &y)
 }
 

--- a/src/spag/template.rs
+++ b/src/spag/template.rs
@@ -173,7 +173,7 @@ impl<'a> Tokenizer<'a> {
     fn read_text(&mut self) -> Result<Token<'a>, String> {
         if self.eof() { return Err("Expected text?".to_string()); }
         let &(start, _) = self.peek().unwrap();
-        let mut end;
+        let end;
         loop {
             if self.eof() {
                 end = self.text.len();
@@ -335,7 +335,7 @@ impl<'a> Tokenizer<'a> {
             return Err("Found eof while reading default value. Unclosed braces".to_string());
         }
         let &(start, _) = self.peek().unwrap();
-        let mut end;
+        let end;
         loop {
             if self.eof() {
                 return Err("Found eof while reading default value. Unclosed braces".to_string());
@@ -360,7 +360,7 @@ impl<'a> Tokenizer<'a> {
             return Err("Expected a name but found eof".to_string());
         }
         let &(start, _) = self.peek().unwrap();
-        let mut end;
+        let end;
         loop {
             if self.eof() {
                 end = self.text.len();

--- a/tests/test_spag.py
+++ b/tests/test_spag.py
@@ -228,34 +228,6 @@ class TestSpagFiles(BaseTest):
         super(TestSpagFiles, self).setUp()
         run_spag('env', 'set', 'endpoint', ENDPOINT)
         run_spag('env', 'set', 'dir', RESOURCES_DIR)
-        # self.table = files.SpagFilesLookup(RESOURCES_DIR)
-
-    @unittest.skip('Should be a unit test')
-    def test_spag_lookup(self):
-        expected = {
-            'auth.yml': set([
-                os.path.join(RESOURCES_DIR, 'auth.yml')]),
-            'delete_thing.yml': set([
-                os.path.join(RESOURCES_DIR, 'delete_thing.yml')]),
-            'patch_thing.yml': set([
-                os.path.join(V2_RESOURCES_DIR, 'patch_thing.yml')]),
-            'post_thing.yml': set([
-                os.path.join(V1_RESOURCES_DIR, 'post_thing.yml'),
-                os.path.join(V2_RESOURCES_DIR, 'post_thing.yml')]),
-            'get_thing.yml': set([
-                os.path.join(V1_RESOURCES_DIR, 'get_thing.yml'),
-                os.path.join(V2_RESOURCES_DIR, 'get_thing.yml')]),
-            'headers.yml': set([
-                os.path.join(RESOURCES_DIR, 'headers.yml')]),
-        }
-        self.assertEqual(self.table, expected)
-
-    @unittest.skip('Should be a unit test')
-    def test_spag_load_file(self):
-        content = files.load_file(os.path.join(RESOURCES_DIR, 'auth.yml'))
-        self.assertEqual(content['method'], 'GET')
-        self.assertEqual(content['uri'], '/auth')
-        self.assertEqual(content['headers'], {'Accept': 'application/json'})
 
     def test_spag_request_get(self):
         for name in ('auth.yml', 'auth'):
@@ -306,8 +278,24 @@ class TestSpagFiles(BaseTest):
         self.assertEqual(json.loads(out), {"Hello": "abcde"})
         self.assertEqual(ret, 0)
 
-    def test_spag_list_requests(self):
+    def test_spag_request_list_w_absolute_dir(self):
+        abspath = os.path.abspath(RESOURCES_DIR)
+        _, err, ret = run_spag('env', 'set', 'dir', abspath)
+        self.assertEqual(err, '')
+        self.assertEqual(ret, 0)
+
         out, err, ret = run_spag('request', 'list')
+        self._check_spag_request_list(*run_spag('request', 'list'))
+
+    def test_spag_request_list_w_relative_dir(self):
+        relpath = os.path.relpath(RESOURCES_DIR)
+        _, err, ret = run_spag('env', 'set', 'dir', relpath)
+        self.assertEqual(err, '')
+        self.assertEqual(ret, 0)
+
+        self._check_spag_request_list(*run_spag('request', 'list'))
+
+    def _check_spag_request_list(self, out, err, ret):
         def parse(text):
             return text.split()
         expected = """

--- a/tests/test_spag.py
+++ b/tests/test_spag.py
@@ -8,7 +8,8 @@ import textwrap
 import yaml
 
 # TODO: read this from a config?
-SPAG_PROG = './target/debug/spag'
+SPAG_PROG = os.environ.get('SPAG_TEST_EXE', './target/debug/spag')
+print "Using spag at %s" % SPAG_PROG
 ENDPOINT = 'http://localhost:5000'
 RESOURCES_DIR = os.path.join(os.path.dirname(__file__), 'resources')
 TEMPLATES_DIR = os.path.join(os.path.dirname(__file__), 'templates')


### PR DESCRIPTION
- [x] `-v` or `--verbose` shows the same thing as `spag history show ...`
- [x] `spag <method>` and `spag request` accept `-r <name>` or `--remember-as <name>`, so that you can then grab data from that request using `{{ <name>.response.body.id }}`
- [x] Fix `spag request list` panicking on a relative dir in the environment
- [x] travis now builds and tests on the release build
- [x] no warnings on `cargo build`