### PR TITLE
Fixing error messages and `spag request show-params`

### DIFF
--- a/src/spag/args.rs
+++ b/src/spag/args.rs
@@ -29,6 +29,7 @@ Usage:
     spag (get|post|put|patch|delete) <resource> [(-H <header>)...] [-e <endpoint>] [-d <data>] [(--with <key> <val>)...] [-v] [--remember-as <name>]
     spag request list [--dir <dir>]
     spag request show <file>
+    spag request show-params <file>
     spag request <file> [-v] [(-H <header>)...] [-e <endpoint>] [-d <data>] [(--with <key> <val>)...] [--dir <dir>] [--remember-as <name>]
     spag history
     spag history show <index>

--- a/src/spag/main.rs
+++ b/src/spag/main.rs
@@ -114,6 +114,8 @@ fn spag_request(args: &Args) {
         spag_request_list(args);
     } else if args.cmd_show {
         spag_request_show(args);
+    } else if args.cmd_show_params {
+        spag_request_show_params(args);
     } else {
         spag_request_a_file(args);
     }
@@ -170,6 +172,15 @@ fn spag_request_show(args: &Args) {
     let filename = try_error!(request::get_request_filename(&args.arg_file, &dir));
     let contents = try_error!(file::read_file(&filename));
     println!("{}", contents);
+}
+
+fn spag_request_show_params(args: &Args) {
+    let dir = try_error!(args::get_dir(args));
+    let filename = try_error!(request::get_request_filename(&args.arg_file, &dir));
+    let contents = try_error!(file::read_file(&filename));
+    let use_shortcuts = true;
+    let out = try_error!(template::show_params(&contents, use_shortcuts));
+    println!("{}", out);
 }
 
 fn spag_request_list(args: &Args) {

--- a/src/spag/test.rs
+++ b/src/spag/test.rs
@@ -165,3 +165,23 @@ use super::yaml_util;
     let result = template::untemplate("@a", &withs, true);
     assert!(result.is_err());
 }
+
+#[test] fn test_show_params_for_options() {
+    let options = vec![
+        Token::With("with-key"),
+        Token::Env("", vec!["a", "b", "c"]),
+        Token::Env("myenv", vec!["c", "d", "e"]),
+        Token::Request("last", vec!["body".to_string(), "id".to_string()]),
+        Token::Request("other", vec!["headers".to_string(), "accept".to_string()]),
+    ];
+
+    let result = template::show_params_for_options(&options).unwrap();
+    let expected = concat!(
+        "{{ with-key, [].a.b.c, [myenv].c.d.e, last.body.id, other.headers.accept }} needs one of\n",
+        "    * flag \"--with with-key <value>\"\n",
+        "    * key [\"a\", \"b\", \"c\"] from the active environment\n",
+        "    * key [\"c\", \"d\", \"e\"] from environment \"myenv\"\n",
+        "    * key [\"body\", \"id\"] from the previous request\n",
+        "    * key [\"headers\", \"accept\"] from the request saved as \"other\"\n");
+    assert_eq!(result.as_str(), expected);
+}

--- a/src/spag/test.rs
+++ b/src/spag/test.rs
@@ -5,7 +5,7 @@ use rustc_serialize::json::Json;
 
 use super::file;
 use super::template;
-use super::template::Token;
+use super::template::{Token, Choice};
 use super::remember;
 use super::yaml_util;
 
@@ -84,9 +84,9 @@ use super::yaml_util;
     let tokens = template::Tokenizer::new("{{wumbo, aaa.bbb : ccc }}", true).tokenize().unwrap();
     assert_eq!(tokens, vec![
         Token::Substitute(vec![
-            Token::With("wumbo"),
-            Token::Request("aaa", vec!["bbb".to_string()]),
-            Token::DefaultVal("ccc"),
+            Choice::With("wumbo"),
+            Choice::Request("aaa", vec!["bbb".to_string()]),
+            Choice::DefaultVal("ccc"),
         ])]);
 }
 
@@ -94,14 +94,14 @@ use super::yaml_util;
     let key_path = vec!["response".to_string(), "body".to_string(), "wumbo".to_string()];
 
     let tokens = template::Tokenizer::new("@wumbo", true).tokenize().unwrap();
-    assert_eq!(tokens, vec![ Token::Substitute(vec![ Token::Request("last", key_path.clone()) ])]);
+    assert_eq!(tokens, vec![ Token::Substitute(vec![ Choice::Request("last", key_path.clone()) ])]);
 
     let tokens = template::Tokenizer::new("@body.wumbo", true).tokenize().unwrap();
-    assert_eq!(tokens, vec![ Token::Substitute(vec![ Token::Request("last", key_path.clone()) ])]);
+    assert_eq!(tokens, vec![ Token::Substitute(vec![ Choice::Request("last", key_path.clone()) ])]);
 
     let key_path = vec!["response".to_string(), "body".to_string(), "things".to_string(), "0".to_string(), "id".to_string()];
     let tokens = template::Tokenizer::new("@body.things.0.id", true).tokenize().unwrap();
-    assert_eq!(tokens, vec![ Token::Substitute(vec![ Token::Request("last", key_path) ])]);
+    assert_eq!(tokens, vec![ Token::Substitute(vec![ Choice::Request("last", key_path) ])]);
 }
 
 #[test] fn test_tokenize_text_list_shortcut_together() {
@@ -111,9 +111,9 @@ use super::yaml_util;
     let key_path = vec!["response".to_string(), "body".to_string(), "id".to_string()];
     assert_eq!(tokens, vec![
         Token::Text("  pglbutt   "),
-        Token::Substitute(vec![ Token::Env("yaml_util", vec!["wumbo", "thing_1234567890"]) ]),
+        Token::Substitute(vec![ Choice::Env("yaml_util", vec!["wumbo", "thing_1234567890"]) ]),
         Token::Text("/poo"),
-        Token::Substitute(vec![ Token::Request("last", key_path) ]),
+        Token::Substitute(vec![ Choice::Request("last", key_path) ]),
         Token::Text("\t\nhello \t"),
     ]);
 }
@@ -122,7 +122,7 @@ use super::yaml_util;
     let tokens = template::Tokenizer::new("@a{{b}}", false).tokenize().unwrap();
     assert_eq!(tokens, vec![
         Token::Text("@a"),
-        Token::Substitute(vec![ Token::With("b") ]),
+        Token::Substitute(vec![ Choice::With("b") ]),
     ]);
 }
 
@@ -166,16 +166,16 @@ use super::yaml_util;
     assert!(result.is_err());
 }
 
-#[test] fn test_show_params_for_options() {
+#[test] fn test_show_params_for_choices() {
     let options = vec![
-        Token::With("with-key"),
-        Token::Env("", vec!["a", "b", "c"]),
-        Token::Env("myenv", vec!["c", "d", "e"]),
-        Token::Request("last", vec!["body".to_string(), "id".to_string()]),
-        Token::Request("other", vec!["headers".to_string(), "accept".to_string()]),
+        Choice::With("with-key"),
+        Choice::Env("", vec!["a", "b", "c"]),
+        Choice::Env("myenv", vec!["c", "d", "e"]),
+        Choice::Request("last", vec!["body".to_string(), "id".to_string()]),
+        Choice::Request("other", vec!["headers".to_string(), "accept".to_string()]),
     ];
 
-    let result = template::show_params_for_options(&options).unwrap();
+    let result = template::show_params_for_choices(&options).unwrap();
     let expected = concat!(
         "{{ with-key, [].a.b.c, [myenv].c.d.e, last.body.id, other.headers.accept }} needs one of\n",
         "    * flag \"--with with-key <value>\"\n",

--- a/tests/templates/show_params_test.yml
+++ b/tests/templates/show_params_test.yml
@@ -1,0 +1,4 @@
+method: GET
+uri: /{{ tenant, [].tenant, [myenv].tenant : noauth-project }}/things
+headers:
+    X-Auth-Token: {{ last.response.body.id, other.response.body.id }}

--- a/tests/test_spag.py
+++ b/tests/test_spag.py
@@ -807,6 +807,21 @@ class TestSpagTemplate(BaseTest):
         _, err, _ = run_spag('get', '/things/@/')
         self.assertEqual(err.strip(), "Invalid character '/' found in template item")
 
+    def test_show_params(self):
+        out, err, ret = run_spag('request', 'show-params', 'show_params_test')
+        self.assertEqual(err, '')
+        self.assertEqual(ret, 0)
+        self.assertEqual(out.strip(),
+            textwrap.dedent("""
+            {{ tenant, [].tenant, [myenv].tenant: noauth-project }} needs one of
+                * flag "--with tenant <value>"
+                * key ["tenant"] from the active environment
+                * key ["tenant"] from environment "myenv"
+                * defaults to "noauth-project" if no matches are found
+            {{ last.response.body.id, other.response.body.id }} needs one of
+                * key ["response", "body", "id"] from the previous request
+                * key ["response", "body", "id"] from the request saved as "other"
+            """).strip())
 
 class TestSpagHistory(BaseTest):
 

--- a/tests/test_spag.py
+++ b/tests/test_spag.py
@@ -752,6 +752,62 @@ class TestSpagTemplate(BaseTest):
         self.assertEqual(ret, 0)
         self.assertEquals(json.loads(out), {"id": "wumbo"})
 
+    def test_error_using_shortcut_syntax_inside_template_list(self):
+        out, err, ret = run_spag('get', '/things/{{a, @id}}')
+        self.assertEqual(err.strip(), "Invalid character '@' found in template item")
+        self.assertEqual(ret, 1)
+        self.assertEqual(out, '')
+
+    def test_shortcut_syntax_allows_underscores_and_dashes(self):
+        out, err, ret = run_spag('env', 'set', '_my-wumbo_', 'mini')
+        self.assertEqual((err, ret), ('', 0))
+
+        out, err, ret = run_spag('request', 'post_thing',
+                                 '--with', 'thing_id', '@[]._my-wumbo_')
+        self.assertEqual(err, '')
+        self.assertEqual(ret, 0)
+        self.assertEqual(json.loads(out), {"id": "mini"})
+
+    def test_error_message_on_empty_list(self):
+        _, err, _ = run_spag('get', '/things/{{}}')
+        self.assertEqual(err.strip(),
+            "Expected a template list item, but found the end of the list '}}'")
+
+    def test_error_message_on_unclosed_list(self):
+        eof_msg = "Expected a template list item, but found eof"
+        _, err, _ = run_spag('get', '/things/{{')
+        self.assertEqual(err.strip(), eof_msg)
+
+        _, err, _ = run_spag('get', '/things/@')
+        self.assertEqual(err.strip(), eof_msg)
+
+    def test_error_message_on_missing_list_item(self):
+        _, err, _ = run_spag('get', '/things/@:')
+        self.assertEqual(err.strip(), "Expected a template list item, but found ':'")
+
+        _, err, _ = run_spag('get', '/things/@ :')
+        self.assertEqual(err.strip(), "Expected a template list item, but found ':'")
+
+        _, err, _ = run_spag('get', '/things/{{ : ')
+        self.assertEqual(err.strip(), "Expected a template list item, but found ':'")
+
+        _, err, _ = run_spag('get', '/things/@,')
+        self.assertEqual(err.strip(), "Expected a template list item, but found ','")
+
+        _, err, _ = run_spag('get', '/things/@ ,')
+        self.assertEqual(err.strip(), "Expected a template list item, but found ','")
+
+        _, err, _ = run_spag('get', '/things/{{ : ')
+        self.assertEqual(err.strip(), "Expected a template list item, but found ':'")
+
+    def test_error_message_on_invalid_list_item(self):
+        _, err, _ = run_spag('get', '/things/{{/}} ')
+        self.assertEqual(err.strip(), "Invalid character '/' found in template item")
+
+        _, err, _ = run_spag('get', '/things/@/')
+        self.assertEqual(err.strip(), "Invalid character '/' found in template item")
+
+
 class TestSpagHistory(BaseTest):
 
     def setUp(self):


### PR DESCRIPTION
- [x] Support `-` in template keys so things like `@api-key` work
- [x] Improve some template error messages
- [x] Add `spag request show-params <file>`
- [x] Refactor Token enum to remove a few places where we had `_ => { println!("BUG: ... }; }`

`spag request show-params ...` prints out:

	{{ tenant, [].tenant, [myenv].tenant: noauth-project }} needs one of
		* flag "--with tenant <value>"
		* key ["tenant"] from the active environment
		* key ["tenant"] from environment "myenv"
		* defaults to "noauth-project" if no matches are found
	{{ last.response.body.id, other.response.body.id }} needs one of
		* key ["response", "body", "id"] from the previous request
		* key ["response", "body", "id"] from the request saved as "other"

