### PR TITLE
Refactor cli args

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,6 @@ docs/_build/
 
 # PyBuilder
 target/
+
+.spag/
+.venv/

--- a/src/spag/args.rs
+++ b/src/spag/args.rs
@@ -52,11 +52,11 @@ Arguments:
 
 docopt!(pub RequestArgs derive Debug, "
 Usage:
-    spag request --help
-    spag request ls [--dir <dir>]
-    spag request cat <file>
-    spag request inspect <file>
-    spag request <file> [options] [(-H <header>)...] [(-w|--with <key> <val>)...]
+    spag (request|r) --help
+    spag (request|r) ls [--dir <dir>]
+    spag (request|r) cat <file>
+    spag (request|r) inspect <file>
+    spag (request|r) <file> [options] [(-H <header>)...] [(-w|--with <key> <val>)...]
 
 Options:
     -h --help                   Show this message

--- a/src/spag/args.rs
+++ b/src/spag/args.rs
@@ -17,16 +17,17 @@ use super::yaml_util;
 
 docopt!(pub MainArgs derive Debug, "
 Usage:
-    spag <command> [<args>...]
     spag [options]
+    spag <command> [<args>...]
 
 Options:
-    -h, --help
+    -h --help       Show this message
 
 Commands:
-    env
-    request
-    history
+    env             Manage spag environments
+    request         Send predefined request files
+    history         View request history
+    <method>        Perform an HTTP request: get, post, patch, delete, etc
 ");
 
 docopt!(pub EnvArgs derive Debug, "
@@ -40,15 +41,13 @@ Usage:
     spag env list
 
 Options:
-    -h --help                  Show this message
-    -E --everything            Unset an entire environment
+    -h --help           Show this message
+    -E --everything     Unset an entire environment
 
 Arguments:
-    <endpoint>      The base url of the service, like 'http://localhost:5000'
-    <resource>      The path of an api resource, like '/v2/things'
-    <header>        An http header, like 'Content-type: application/json'
-    <environment>   The name of an environment, like 'default'
-    <index>         An index, starting at zero
+    <environment>       The name of an environment, like 'default'
+    <key>               The key name of a value to set, like 'headers.Content-type'
+    <val>               The value to set on the given key
 ");
 
 docopt!(pub RequestArgs derive Debug, "
@@ -57,23 +56,20 @@ Usage:
     spag request list [--dir <dir>]
     spag request show <file>
     spag request show-params <file>
-    spag request <file> [-v] [(-H <header>)...] [-e <endpoint>] [-d <data>] [(--with <key> <val>)...] [--dir <dir>] [--remember-as <name>]
+    spag request <file> [options] [(-H <header>)...] [(-w|--with <key> <val>)...]
 
 Options:
-    -h, --help                  Show this message
-    -H, --header <header>       Supply a header
-    -e, --endpoint <endpoint>   Supply the endpoint
-    -d, --data <data>           Supply the request body
-    -v, --verbose               Print out more of the request and response
-    -r, --remember-as <name>    Additionally, remember this request under the given name
+    -h --help                   Show this message
+    -H --header <header>        Supply a header
+    -e --endpoint <endpoint>    Supply the endpoint
+    -d --data <data>            Supply the request body
+    -v --verbose                Print out more of the request and response
+    -r --remember-as <name>     Additionally, remember this request under the given name
     --dir <dir>                 The directory containing request files
 
 Arguments:
     <endpoint>      The base url of the service, like 'http://localhost:5000'
-    <resource>      The path of an api resource, like '/v2/things'
     <header>        An http header, like 'Content-type: application/json'
-    <environment>   The name of an environment, like 'default'
-    <index>         An index, starting at zero
 ");
 
 docopt!(pub HistoryArgs derive Debug, "
@@ -82,7 +78,7 @@ Usage:
     spag history show <index>
 
 Options:
-    -h, --help      Show this message
+    -h --help       Show this message
 
 Arguments:
     <index>         An index, starting at zero
@@ -91,15 +87,15 @@ Arguments:
 docopt!(pub MethodArgs derive Debug, "
 Usage:
     spag <method> --help
-    spag <method> <path> [options] [(-H <header>)...] [(--with|-w <key> <val>)...]
+    spag <method> <path> [options] [(-H <header>)...]
 
 Options:
-    -h, --help                  Show this message
-    -H, --header <header>       Supply a header
-    -e, --endpoint <endpoint>   Supply the endpoint
-    -d, --data <data>           Supply the request body
-    -v, --verbose               Print out more of the request and response
-    -r, --remember-as <name>    Remember this request under the given name
+    -h --help                   Show this message
+    -H --header <header>        Supply a header
+    -e --endpoint <endpoint>    Supply the endpoint
+    -d --data <data>            Supply the request body
+    -v --verbose                Print out more of the request and response
+    -r --remember-as <name>     Remember this request under the given name
 
 Arguments:
     <method>        The http method: get, post, put, patch, delete

--- a/src/spag/args.rs
+++ b/src/spag/args.rs
@@ -75,7 +75,7 @@ Arguments:
 docopt!(pub HistoryArgs derive Debug, "
 Usage:
     spag history [options]
-    spag history show <index>
+    spag history <index>
 
 Options:
     -h --help       Show this message

--- a/src/spag/args.rs
+++ b/src/spag/args.rs
@@ -33,12 +33,12 @@ Commands:
 docopt!(pub EnvArgs derive Debug, "
 Usage:
     spag env --help
-    spag env set (<key> <val>)...
-    spag env unset [(<key>)...] [-E]
-    spag env show [<environment>]
+    spag env ls
+    spag env cat [<environment>]
     spag env activate <environment>
     spag env deactivate
-    spag env list
+    spag env set (<key> <val>)...
+    spag env unset [(<key>)...] [-E]
 
 Options:
     -h --help           Show this message
@@ -53,9 +53,9 @@ Arguments:
 docopt!(pub RequestArgs derive Debug, "
 Usage:
     spag request --help
-    spag request list [--dir <dir>]
-    spag request show <file>
-    spag request show-params <file>
+    spag request ls [--dir <dir>]
+    spag request cat <file>
+    spag request inspect <file>
     spag request <file> [options] [(-H <header>)...] [(-w|--with <key> <val>)...]
 
 Options:

--- a/src/spag/args.rs
+++ b/src/spag/args.rs
@@ -56,7 +56,7 @@ Usage:
     spag (request|r) ls [--dir <dir>]
     spag (request|r) cat <file>
     spag (request|r) inspect <file>
-    spag (request|r) <file> [options] [(-H <header>)...] [(-w|--with <key> <val>)...]
+    spag (request|r) <file> [options] [(-H <header>)...] [(-w <key> <val>|--with <key> <val>)...]
 
 Options:
     -h --help                   Show this message

--- a/src/spag/main.rs
+++ b/src/spag/main.rs
@@ -34,7 +34,7 @@ pub fn main() {
         "env" => {
             spag_env(&args::parse_env_args(&argv))
         },
-        "request" => {
+        "r" | "request" => {
             spag_request(&args::parse_request_args(&argv))
         },
         "history" => {

--- a/src/spag/main.rs
+++ b/src/spag/main.rs
@@ -43,8 +43,14 @@ pub fn main() {
         "get" | "post" | "put" | "patch" | "delete" => {
             spag_method(&args::parse_method_args(&argv))
         },
-        command if command.is_empty() => { error!("No command found"); },
-        command => { error!("Command {} not recognized", command); },
+        command if command.is_empty() => {
+            printerrln!("Received no command or options");
+            args::parse_main_args(&vec![argv[0].to_string(), "--help".to_string()]);
+        },
+        command => {
+            printerrln!("Command '{}' not recognized", command);
+            args::parse_main_args(&vec![argv[0].to_string(), "--help".to_string()]);
+        },
     }
 }
 
@@ -225,10 +231,7 @@ fn spag_request_list(args: &RequestArgs) {
 fn spag_method(args: &MethodArgs) {
     // untemplate the resource
     let use_shortcuts = true;
-    let withs: HashMap<String, String> = args::get_withs(&args.arg_key, &args.arg_val);
-    let withs: HashMap<&str, &str> = withs.iter()
-        .map(|(k, v)| (k.as_str(), v.as_str()))
-        .collect();
+    let withs: HashMap<&str, &str> = HashMap::new();
     let resource = try_error!(template::untemplate(&args.arg_path, &withs, use_shortcuts));
 
     let method = args::get_method_from_args(args);

--- a/src/spag/main.rs
+++ b/src/spag/main.rs
@@ -55,8 +55,8 @@ pub fn main() {
 }
 
 fn spag_env(args: &EnvArgs) {
-    if args.cmd_show {
-        spag_env_show(&args);
+    if args.cmd_cat {
+        spag_env_cat(&args);
     } else if args.cmd_set {
         spag_env_set(&args);
     } else if args.cmd_unset {
@@ -65,8 +65,8 @@ fn spag_env(args: &EnvArgs) {
         spag_env_activate(&args);
     } else if args.cmd_deactivate {
         spag_env_deactivate();
-    } else if args.cmd_list {
-        spag_env_list();
+    } else if args.cmd_ls {
+        spag_env_ls();
     } else {
         error!("BUG: Invalid command");
     }
@@ -100,7 +100,7 @@ fn spag_env_unset(args: &EnvArgs) {
     }
 }
 
-fn spag_env_show(args: &EnvArgs) {
+fn spag_env_cat(args: &EnvArgs) {
     try_error!(env::show_environment(&args.arg_environment));
 }
 
@@ -113,7 +113,7 @@ fn spag_env_deactivate() {
     try_error!(env::deactivate_environment());
 }
 
-fn spag_env_list() {
+fn spag_env_ls() {
     try_error!(env::list_environments());
 }
 
@@ -136,12 +136,12 @@ fn spag_history_show(args: &HistoryArgs) {
 }
 
 fn spag_request(args: &RequestArgs) {
-    if args.cmd_list {
-        spag_request_list(args);
-    } else if args.cmd_show {
-        spag_request_show(args);
-    } else if args.cmd_show_params {
-        spag_request_show_params(args);
+    if args.cmd_ls {
+        spag_request_ls(args);
+    } else if args.cmd_cat {
+        spag_request_cat(args);
+    } else if args.cmd_inspect {
+        spag_request_inspect(args);
     } else {
         spag_request_a_file(args);
     }
@@ -193,14 +193,14 @@ fn spag_request_a_file(args: &RequestArgs) {
     }
 }
 
-fn spag_request_show(args: &RequestArgs) {
+fn spag_request_cat(args: &RequestArgs) {
     let dir = try_error!(args::get_dir(args));
     let filename = try_error!(request::get_request_filename(&args.arg_file, &dir));
     let contents = try_error!(file::read_file(&filename));
     println!("{}", contents);
 }
 
-fn spag_request_show_params(args: &RequestArgs) {
+fn spag_request_inspect(args: &RequestArgs) {
     let dir = try_error!(args::get_dir(args));
     let filename = try_error!(request::get_request_filename(&args.arg_file, &dir));
     let contents = try_error!(file::read_file(&filename));
@@ -209,7 +209,7 @@ fn spag_request_show_params(args: &RequestArgs) {
     println!("{}", out);
 }
 
-fn spag_request_list(args: &RequestArgs) {
+fn spag_request_ls(args: &RequestArgs) {
     let dir = try_error!(args::get_dir(args));
     let filenames = try_error!(file::walk_dir(&dir));
     let mut yaml_files: Vec<&PathBuf> = filenames.iter()

--- a/src/spag/main.rs
+++ b/src/spag/main.rs
@@ -10,7 +10,12 @@ use curl::http;
 use yaml_rust::Yaml;
 
 use super::args;
-use super::args::Args;
+use super::args::EnvArgs;
+use super::args::MainArgs;
+use super::args::MethodArgs;
+use super::args::RequestArgs;
+use super::args::HistoryArgs;
+
 use super::env;
 use super::file;
 use super::history;
@@ -22,19 +27,28 @@ use super::yaml_util;
 
 
 pub fn main() {
-    let args: Args = args::parse_args();
-    if args.cmd_request {
-        spag_request(&args);
-    } else if args.cmd_history {
-        spag_history(&args);
-    } else if args.cmd_env {
-        spag_env(&args);
-    } else if args.cmd_get || args.cmd_post || args.cmd_put || args.cmd_patch || args.cmd_delete {
-        spag_method(&args);
+    let argv: Vec<String> = std::env::args().collect();
+    let main_argv: Vec<String> = std::env::args().take(2).collect();
+    let args: MainArgs = args::parse_main_args(&main_argv);
+    match args.arg_command.as_str() {
+        "env" => {
+            spag_env(&args::parse_env_args(&argv))
+        },
+        "request" => {
+            spag_request(&args::parse_request_args(&argv))
+        },
+        "history" => {
+            spag_history(&args::parse_history_args(&argv))
+        },
+        "get" | "post" | "put" | "patch" | "delete" => {
+            spag_method(&args::parse_method_args(&argv))
+        },
+        command if command.is_empty() => { error!("No command found"); },
+        command => { error!("Command {} not recognized", command); },
     }
 }
 
-fn spag_env(args: &Args) {
+fn spag_env(args: &EnvArgs) {
     if args.cmd_show {
         spag_env_show(&args);
     } else if args.cmd_set {
@@ -52,9 +66,9 @@ fn spag_env(args: &Args) {
     }
 }
 
-fn spag_env_set(args: &Args) {
+fn spag_env_set(args: &EnvArgs) {
     let use_shortcuts = true;
-    let withs: HashMap<String, String> = args::get_withs(args);
+    let withs: HashMap<String, String> = args::get_withs(&args.arg_key, &args.arg_val);
     let withs: HashMap<&str, &str> = withs.iter()
         .map(|(k, v)| (k.as_str(), v.as_str()))
         .collect();
@@ -70,7 +84,7 @@ fn spag_env_set(args: &Args) {
     try_error!(env::show_environment(&args.arg_environment));
 }
 
-fn spag_env_unset(args: &Args) {
+fn spag_env_unset(args: &EnvArgs) {
     if !args.flag_everything {
         try_error!(env::unset_in_environment(&args.arg_environment, &args.arg_key));
         try_error!(env::show_environment(&args.arg_environment));
@@ -80,11 +94,11 @@ fn spag_env_unset(args: &Args) {
     }
 }
 
-fn spag_env_show(args: &Args) {
+fn spag_env_show(args: &EnvArgs) {
     try_error!(env::show_environment(&args.arg_environment));
 }
 
-fn spag_env_activate(args: &Args) {
+fn spag_env_activate(args: &EnvArgs) {
     try_error!(env::set_active_environment(&args.arg_environment));
     try_error!(env::show_environment(&args.arg_environment));
 }
@@ -97,7 +111,7 @@ fn spag_env_list() {
     try_error!(env::list_environments());
 }
 
-fn spag_history(args: &Args) {
+fn spag_history(args: &HistoryArgs) {
     if args.cmd_show {
         spag_history_show(&args);
     } else {
@@ -110,12 +124,12 @@ fn spag_history(args: &Args) {
     }
 }
 
-fn spag_history_show(args: &Args) {
+fn spag_history_show(args: &HistoryArgs) {
     let out = try_error!(history::get(&args.arg_index));
     println!("{}", out);
 }
 
-fn spag_request(args: &Args) {
+fn spag_request(args: &RequestArgs) {
     if args.cmd_list {
         spag_request_list(args);
     } else if args.cmd_show {
@@ -127,10 +141,10 @@ fn spag_request(args: &Args) {
     }
 }
 
-fn spag_request_a_file(args: &Args) {
-    let endpoint = try_error!(args::get_endpoint(args));
+fn spag_request_a_file(args: &RequestArgs) {
+    let endpoint = try_error!(args::get_endpoint(&args.flag_endpoint));
     let dir = try_error!(args::get_dir(args));
-    let withs: HashMap<String, String> = args::get_withs(args);
+    let withs: HashMap<String, String> = args::get_withs(&args.arg_key, &args.arg_val);
     let withs: HashMap<&str, &str> = withs.iter()
         .map(|(k, v)| (k.as_str(), v.as_str()))
         .collect();
@@ -150,7 +164,7 @@ fn spag_request_a_file(args: &Args) {
             //
             // todo? because docopt defaults to an empty string if the data flag isn't given,
             // we can't tell if the user is trying to override the body to be empty.
-            let data = try_error!(args::get_data(args));
+            let data = try_error!(args::get_data(&args.flag_data, &withs));
             let body =
                 if !data.is_empty() {
                     data
@@ -162,25 +176,25 @@ fn spag_request_a_file(args: &Args) {
                     }
                 };
 
-            let headers = try_error!(args::resolve_headers(args, &y));
+            let headers = try_error!(args::resolve_headers(&args.flag_header, &y));
 
             let mut req = SpagRequest::new(request::method_from_str(&method), endpoint, uri);
             try_error!(req.add_headers(headers.iter()));
             req.set_body(body);
-            do_request(args, &req);
+            do_request(&req, &args.flag_remember_as, args.flag_verbose);
         },
         Err(msg) => { error!("{}", msg); }
     }
 }
 
-fn spag_request_show(args: &Args) {
+fn spag_request_show(args: &RequestArgs) {
     let dir = try_error!(args::get_dir(args));
     let filename = try_error!(request::get_request_filename(&args.arg_file, &dir));
     let contents = try_error!(file::read_file(&filename));
     println!("{}", contents);
 }
 
-fn spag_request_show_params(args: &Args) {
+fn spag_request_show_params(args: &RequestArgs) {
     let dir = try_error!(args::get_dir(args));
     let filename = try_error!(request::get_request_filename(&args.arg_file, &dir));
     let contents = try_error!(file::read_file(&filename));
@@ -189,7 +203,7 @@ fn spag_request_show_params(args: &Args) {
     println!("{}", out);
 }
 
-fn spag_request_list(args: &Args) {
+fn spag_request_list(args: &RequestArgs) {
     let dir = try_error!(args::get_dir(args));
     let filenames = try_error!(file::walk_dir(&dir));
     let mut yaml_files: Vec<&PathBuf> = filenames.iter()
@@ -208,36 +222,36 @@ fn spag_request_list(args: &Args) {
     }
 }
 
-fn spag_method(args: &Args) {
+fn spag_method(args: &MethodArgs) {
     // untemplate the resource
     let use_shortcuts = true;
-    let withs: HashMap<String, String> = args::get_withs(args);
+    let withs: HashMap<String, String> = args::get_withs(&args.arg_key, &args.arg_val);
     let withs: HashMap<&str, &str> = withs.iter()
         .map(|(k, v)| (k.as_str(), v.as_str()))
         .collect();
-    let resource = try_error!(template::untemplate(&args.arg_resource, &withs, use_shortcuts));
+    let resource = try_error!(template::untemplate(&args.arg_path, &withs, use_shortcuts));
 
     let method = args::get_method_from_args(args);
-    let endpoint = try_error!(args::get_endpoint(args));
+    let endpoint = try_error!(args::get_endpoint(&args.flag_endpoint));
     let mut req = SpagRequest::new(method, endpoint, resource);
-    let headers = try_error!(args::resolve_headers_no_request_file(args));
+    let headers = try_error!(args::resolve_headers_no_request_file(&args.flag_header));
     try_error!(req.add_headers(headers.iter()));
 
-    let body = try_error!(args::get_data(args));
+    let body = try_error!(args::get_data(&args.flag_data, &withs));
     req.set_body(body);
-    do_request(args, &req);
+    do_request(&req, &args.flag_remember_as, args.flag_verbose);
 }
 
-fn do_request(args: &Args, req: &SpagRequest) {
+fn do_request(req: &SpagRequest, remember_as: &str, verbose: bool) {
     let mut handle = http::handle();
     let resp = try_error!(req.prepare(&mut handle).exec());
     try_error!(history::append(req, &resp));
     try_error!(remember::remember(req, &resp, "last.yml"));
-    if !args.flag_remember_as.is_empty() {
-        try_error!(remember::remember(req, &resp, &args.flag_remember_as));
+    if !remember_as.is_empty() {
+        try_error!(remember::remember(req, &resp, remember_as));
     }
 
-    if args.flag_verbose {
+    if verbose {
         let out = try_error!(history::get(&"0".to_string()));
         println!("{}", out);
     } else {

--- a/src/spag/main.rs
+++ b/src/spag/main.rs
@@ -118,7 +118,7 @@ fn spag_env_ls() {
 }
 
 fn spag_history(args: &HistoryArgs) {
-    if args.cmd_show {
+    if !args.arg_index.is_empty() {
         spag_history_show(&args);
     } else {
         let short = try_error!(history::list());

--- a/src/spag/mod.rs
+++ b/src/spag/mod.rs
@@ -29,6 +29,13 @@ macro_rules! try_error {
     })
 }
 
+#[macro_export]
+macro_rules! parse_args {
+    ($argtype:ident, $argv:expr) => (
+        $argtype::docopt().argv($argv.iter().map(|s| &s[..])).decode().unwrap_or_else(|e| e.exit())
+    )
+}
+
 pub mod args;
 pub mod env;
 pub mod file;

--- a/src/spag/mod.rs
+++ b/src/spag/mod.rs
@@ -1,3 +1,14 @@
+/// A macro to print to stderr, just like println!
+macro_rules! printerrln (
+    ($($arg:tt)*) => (
+        match writeln!(&mut ::std::io::stderr(), $($arg)* ) {
+            Ok(_) => {},
+            Err(x) => panic!("Unable to write to stderr: {}", x),
+        }
+    )
+);
+
+
 /// Formats a string which is printed to stderr, and exits with status code 1
 ///
 /// ```
@@ -6,10 +17,7 @@
 #[macro_export]
 macro_rules! error {
     ($($arg:tt)*) => ({
-        match writeln!(&mut std::io::stderr(), $($arg)*) {
-            Ok(_) => {},
-            Err(x) => panic!("Unable to write to stderr: {}", x),
-        }
+        printerrln!($($arg)*);
         std::process::exit(1);
     })
 }

--- a/tests/test_spag.py
+++ b/tests/test_spag.py
@@ -580,6 +580,13 @@ class TestSpagTemplate(BaseTest):
         self.assertEqual(json.loads(out), {"id": "wumbo"})
         self.assertEqual(ret, 0)
 
+    def test_spag_template_with_keyword_short_flag(self):
+        out, err, ret = run_spag('request', 'templates/post_thing',
+                                 '-w', 'thing_id', 'wumbo')
+        self.assertEqual(err, '')
+        self.assertEqual(json.loads(out), {"id": "wumbo"})
+        self.assertEqual(ret, 0)
+
     def test_spag_template_no_value_given(self):
         out, err, ret = run_spag('request', 'templates/post_thing')
         self.assertEqual(err, 'Failed to substitute for {{ thing_id }}\n')

--- a/tests/test_spag.py
+++ b/tests/test_spag.py
@@ -265,11 +265,12 @@ class TestSpagFiles(BaseTest):
         run_spag('env', 'set', 'dir', RESOURCES_DIR)
 
     def test_spag_request_get(self):
-        for name in ('auth.yml', 'auth'):
-            out, err, ret = run_spag('request', name)
-            self.assertEqual(ret, 0)
-            self.assertEqual(json.loads(out), {"token": "abcde"})
-            self.assertEqual(err, '')
+        for command in ('r', 'request'):
+            for name in ('auth.yml', 'auth'):
+                out, err, ret = run_spag(command, name)
+                self.assertEqual(err, '')
+                self.assertEqual(ret, 0)
+                self.assertEqual(json.loads(out), {"token": "abcde"})
 
     def test_spag_request_post(self):
         out, err, ret = run_spag('request', 'v2/post_thing.yml')

--- a/tests/test_spag.py
+++ b/tests/test_spag.py
@@ -314,24 +314,24 @@ class TestSpagFiles(BaseTest):
         self.assertEqual(json.loads(out), {"Hello": "abcde"})
         self.assertEqual(ret, 0)
 
-    def test_spag_request_list_w_absolute_dir(self):
+    def test_spag_request_ls_w_absolute_dir(self):
         abspath = os.path.abspath(RESOURCES_DIR)
         _, err, ret = run_spag('env', 'set', 'dir', abspath)
         self.assertEqual(err, '')
         self.assertEqual(ret, 0)
 
         out, err, ret = run_spag('request', 'ls')
-        self._check_spag_request_list(*run_spag('request', 'ls'))
+        self._check_spag_request_ls(*run_spag('request', 'ls'))
 
-    def test_spag_request_list_w_relative_dir(self):
+    def test_spag_request_ls_w_relative_dir(self):
         relpath = os.path.relpath(RESOURCES_DIR)
         _, err, ret = run_spag('env', 'set', 'dir', relpath)
         self.assertEqual(err, '')
         self.assertEqual(ret, 0)
 
-        self._check_spag_request_list(*run_spag('request', 'ls'))
+        self._check_spag_request_ls(*run_spag('request', 'ls'))
 
-    def _check_spag_request_list(self, out, err, ret):
+    def _check_spag_request_ls(self, out, err, ret):
         def parse(text):
             return text.split()
         expected = """
@@ -348,7 +348,7 @@ class TestSpagFiles(BaseTest):
         self.assertEqual(parse(out), parse(expected))
         self.assertEqual(ret, 0)
 
-    def test_spag_show_request(self):
+    def test_spag_cat_request(self):
         out, err, ret = run_spag('request', 'cat', 'auth.yml')
         self.assertEqual(err, '')
         self.assertEqual(out.strip(),
@@ -935,22 +935,22 @@ class TestSpagHistory(BaseTest):
             lambda: run_spag('delete', '/things/wumbo'),
             expected='0: DELETE %s/things/wumbo\n' % ENDPOINT)
 
-    def test_spag_history_show(self):
+    def test_spag_history_show_index(self):
         # Make a request
         _, err, _ = run_spag('get', '/things')
 
-        # check 'spag history show'
-        out, err, ret = run_spag('history', 'show', '0')
+        # check 'spag history <index>'
+        out, err, ret = run_spag('history', '0')
         self.assertEqual(err, '')
         self.assertIn('GET %s/things' % ENDPOINT, out)
         self.assertEqual(ret, 0)
 
-    def test_spag_history_show_invalid_id(self):
+    def test_spag_history_show_index_invalid_id(self):
         # Make a request
         _, err, _ = run_spag('get', '/things')
 
         # Request an invalid ID
-        out, err, ret = run_spag('history', 'show', '9')
+        out, err, ret = run_spag('history', '9')
         self.assertEqual(err, 'No request at #9\n')
         self.assertNotEqual(ret, 0)
 
@@ -974,8 +974,8 @@ class TestSpagHistory(BaseTest):
             .format(ENDPOINT))
         self.assertEqual(ret, 0)
 
-        # check 'spag history show'
-        out, err, ret = run_spag('history', 'show', '1')
+        # check 'spag history <index>'
+        out, err, ret = run_spag('history', '1')
         self.assertEqual(err, '')
         self.assertIn('POST %s/things' % ENDPOINT, out)
         self.assertEqual(ret, 0)
@@ -1000,8 +1000,8 @@ class TestSpagHistory(BaseTest):
             .format(ENDPOINT))
         self.assertEqual(ret, 0)
 
-        # check 'spag history show'
-        out, err, ret = run_spag('history', 'show', '1')
+        # check 'spag history <index>'
+        out, err, ret = run_spag('history', '1')
         self.assertEqual(err, '')
         self.assertIn('POST %s/things' % ENDPOINT, out)
         self.assertEqual(ret, 0)


### PR DESCRIPTION
- [x] Docopt delegates to sub-parsers
- [x] Figure out `-w, --with <key> <val>`
- [x] `spag history show 0` -> `spag history 0`
- [x] Rename `show` -> `cat`
- [x] Rename `list` -> `ls`
- [x] Add an alias `spag r` == `spag request`
