### PR TITLE
Pretty Print JSON

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,8 +8,12 @@ name = "noodles"
 doctest = false
 
 [dependencies]
-docopt = "0.6.66"
-docopt_macros = "0.6.66"
+docopt = "0.6.69"
+# docopt_macros = "0.6.69" When docopt_macros cuts a new release this can come back
 rustc-serialize = "0.3.15"
 curl = "0.2.10"
-yaml-rust = "0.2.0"
+yaml-rust = "0.2.1"
+
+[dependencies.docopt_macros]
+git = "https://github.com/docopt/docopt.rs.git"
+rev = "ba5cf65299c5bf4a67ae7c8efae2791a19f612c4"

--- a/src/spag/main.rs
+++ b/src/spag/main.rs
@@ -248,6 +248,7 @@ fn spag_method(args: &MethodArgs) {
 fn do_request(req: &SpagRequest, remember_as: &str, verbose: bool) {
     let mut handle = http::handle();
     let resp = try_error!(req.prepare(&mut handle).exec());
+
     try_error!(history::append(req, &resp));
     try_error!(remember::remember(req, &resp, "last.yml"));
     if !remember_as.is_empty() {
@@ -258,8 +259,8 @@ fn do_request(req: &SpagRequest, remember_as: &str, verbose: bool) {
         let out = try_error!(history::get(&"0".to_string()));
         println!("{}", out);
     } else {
-        println!("{}", String::from_utf8(resp.get_body().to_vec()).unwrap());
+        let output = std::str::from_utf8(resp.get_body()).unwrap();
+        println!("{}", yaml_util::pretty_json(output));
     }
 
 }
-

--- a/src/spag/remember.rs
+++ b/src/spag/remember.rs
@@ -1,4 +1,4 @@
-use std::str::from_utf8;
+use std::str;
 use std::path::Path;
 
 use rustc_serialize::json::Json;
@@ -27,14 +27,18 @@ pub fn serialize(req: &SpagRequest, resp: &http::Response) -> Yaml {
     yaml_util::set_nested_value(&mut inner_y, &["request", "method"], req.get_method_string());
     yaml_util::set_nested_value(&mut inner_y, &["request", "uri"], req.uri.as_str());
     yaml_util::set_nested_value(&mut inner_y, &["request", "endpoint"], req.endpoint.as_str());
-    yaml_util::set_nested_value(&mut inner_y, &["request", "body"], req.body.as_str());
+
+    let pretty_req_body = yaml_util::pretty_json(req.body.as_str());
+    yaml_util::set_nested_value(&mut inner_y, &["request", "body"], pretty_req_body.as_str());
 
     for (key, value) in &req.headers {
         yaml_util::set_nested_value(&mut inner_y, &["request", "headers", key], value.as_str());
     }
 
     // Add the response data
-    yaml_util::set_nested_value(&mut inner_y, &["response", "body"], from_utf8(resp.get_body()).unwrap());
+    let pretty_resp_body = yaml_util::pretty_json(str::from_utf8(resp.get_body()).unwrap());
+    yaml_util::set_nested_value(&mut inner_y, &["response", "body"], pretty_resp_body.as_str());
+
     yaml_util::set_nested_value(&mut inner_y, &["response", "status"], resp.get_code().to_string().as_str());
     for (key, value) in resp.get_headers() {
         yaml_util::set_nested_value(&mut inner_y, &["response", "headers", key], value[0].as_str());

--- a/src/spag/test.rs
+++ b/src/spag/test.rs
@@ -185,3 +185,10 @@ use super::yaml_util;
         "    * key [\"headers\", \"accept\"] from the request saved as \"other\"\n");
     assert_eq!(result.as_str(), expected);
 }
+
+#[test] fn test_pretty_json() {
+    let text = yaml_util::pretty_json("blah");
+    assert_eq!(text, "blah");
+    let text = yaml_util::pretty_json("{\"id\": \"foo\"}");
+    assert_eq!(text, "{\n  \"id\": \"foo\"\n}");
+}

--- a/src/spag/yaml_util.rs
+++ b/src/spag/yaml_util.rs
@@ -3,6 +3,7 @@ use yaml_rust::Yaml;
 use yaml_rust::yaml::Hash;
 use yaml_rust::YamlEmitter;
 use yaml_rust::YamlLoader;
+use rustc_serialize::json;
 
 use super::file;
 
@@ -108,4 +109,12 @@ pub fn get_nested_value<'a>(y: &'a Yaml, keys: &[&str]) -> Option<&'a Yaml> {
     } else {
         None
     }
+}
+
+// If body can be serialized to JSON, return a pretty JSON string, otherwise return original string 
+pub fn pretty_json(resp_output: &str) -> String {
+    match json::Json::from_str(&resp_output) {
+        Ok(val) => return format!("{}", val.pretty()),
+        Err(_) => return resp_output.to_string(),
+    };
 }

--- a/tests/test_spag.py
+++ b/tests/test_spag.py
@@ -198,6 +198,12 @@ class TestGet(BaseTest):
         self.assertEqual(out.strip()[:len(prefix)], prefix)
         self.assertEqual(out.strip()[-len(suffix):], suffix)
 
+    def test_get_non_formatted_json(self):
+        out, err, ret = run_spag('get', '/rawjson', '-e', ENDPOINT)
+        self.assertEqual(ret, 0)
+        self.assertEqual(out, '{\n  "foo": "bar"\n}\n')
+        self.assertEqual(json.loads(out), {"foo": "bar"})
+
 class TestPost(BaseTest):
 
     def test_spag_post(self):
@@ -788,7 +794,9 @@ class TestSpagTemplate(BaseTest):
             Accept: application/json
             Content-Type: application/json
             Body:
-            {    "id": "wumbo"}
+            {
+              "id": "wumbo"
+            }
             -------------------- Response ---------------------
             Status code 201
             content-length: 19
@@ -912,7 +920,7 @@ class TestSpagHistory(BaseTest):
 
     def test_post_method_history(self):
         self._run_test_method_history(
-            lambda: run_spag('post', '/things', '-d' ,'{"id": "posty"}'),
+            lambda: run_spag('post', '/things', '-d', '{"id": "posty"}'),
             expected='0: POST %s/things\n' % ENDPOINT)
 
     def test_put_method_history(self):

--- a/tests/testapp.py
+++ b/tests/testapp.py
@@ -73,6 +73,9 @@ def headers():
     return jsonify({key: value for key, value in
                     request.headers.items() if key not in ignored_headers})
 
+@app.route('/rawjson', methods=['GET'])
+def raw_json():
+    return '{"foo": "bar"}'
 
 @app.route('/params', methods=['GET'])
 def params():


### PR DESCRIPTION
- [X] Adds a function in `yaml_util` to return a String of pretty JSON
- [X] Utilizes `pretty_json` in regular requests
- [X] Utilizes `pretty_json` in remembering requests
- [X] Python unit test for `/rawjson`
- [X] Rust unit test for `pretty_json`
